### PR TITLE
Add integration test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "node": ">= 0.10"
   },
   "scripts": {
-    "test": "npm run lint && npm run style && mocha -R spec",
+    "test-unit": "npm run lint && npm run style && mocha -b -R spec test/unit",
+    "test-integration": "npm run lint && npm run style && mocha -b -R spec test/integration",
+    "test": "npm run lint && npm run style && mocha -b -R spec",
     "style": "jscs modules test",
     "lint": "jshint index.js modules test"
   },

--- a/test/fixtures/classes/database.js
+++ b/test/fixtures/classes/database.js
@@ -5,6 +5,8 @@ const bPromise = require('bluebird');
 const Knex = require('knex')(config);
 const Bookshelf = require('bookshelf')(Knex);
 
+const tables = ['series', 'authors', 'books', 'stores', 'books_stores'];
+
 function migrateUntil(stopVersion) {
   return Knex.migrate.rollback(config).spread(function (version, file) {
     if (version > stopVersion) {
@@ -14,10 +16,16 @@ function migrateUntil(stopVersion) {
 }
 
 module.exports = Bookshelf;
+
+module.exports.empty = function() {
+  return bPromise.each(tables, function(table) {
+    return Knex.raw('DROP TABLE ' + table);
+  });
+};
+
 module.exports.reset = function () {
   return migrateUntil(0).then(function () {
     return Knex.migrate.latest(config).then(function () {
-      var tables = ['series', 'authors', 'books', 'stores', 'books_stores'];
       return bPromise.each(tables, function (table) {
         return bPromise.each(fantasyDatabase[table], function (record) {
           return Knex(table).insert(record);

--- a/test/fixtures/controllers/authors.js
+++ b/test/fixtures/controllers/authors.js
@@ -1,0 +1,7 @@
+const Endpoints = require('../../../index');
+
+module.exports = new Endpoints.Controller({
+  source: new Endpoints.BookshelfSource({
+    model: require('../models/authors')
+  })
+});

--- a/test/fixtures/controllers/books.js
+++ b/test/fixtures/controllers/books.js
@@ -1,0 +1,7 @@
+const Endpoints = require('../../../index');
+
+module.exports = new Endpoints.Controller({
+  source: new Endpoints.BookshelfSource({
+    model: require('../models/books')
+  })
+});

--- a/test/fixtures/controllers/series.js
+++ b/test/fixtures/controllers/series.js
@@ -1,0 +1,7 @@
+const Endpoints = require('../../../index');
+
+module.exports = new Endpoints.Controller({
+  source: new Endpoints.BookshelfSource({
+    model: require('../models/series')
+  })
+});

--- a/test/fixtures/controllers/stores.js
+++ b/test/fixtures/controllers/stores.js
@@ -1,0 +1,7 @@
+const Endpoints = require('../../../index');
+
+module.exports = new Endpoints.Controller({
+  source: new Endpoints.BookshelfSource({
+    model: require('../models/stores')
+  })
+});

--- a/test/fixtures/mocks/express_request.js
+++ b/test/fixtures/mocks/express_request.js
@@ -1,0 +1,20 @@
+const sinon = require('sinon');
+
+module.exports = function (body) {
+  return {
+    accepts: sinon.stub().returns(false),
+    params: {
+      id: 1
+    },
+    query: {
+      title: 'foo-bar-baz',
+      unSupportedKey: 'something',
+      include: 'books'
+    },
+    body: {
+      mock: {
+        key: 'value'
+      }
+    }
+  };
+};

--- a/test/fixtures/mocks/express_response.js
+++ b/test/fixtures/mocks/express_response.js
@@ -1,0 +1,9 @@
+const sinon = require('sinon');
+
+module.exports = function () {
+  return {
+    set: sinon.stub().returnsThis(),
+    status: sinon.stub().returnsThis(),
+    send: sinon.stub().returnsThis()
+  };
+};

--- a/test/fixtures/mocks/source.js
+++ b/test/fixtures/mocks/source.js
@@ -1,0 +1,23 @@
+function Model () {}
+Model.prototype.destroy = function () {};
+Model.prototype.update = function () {};
+
+Model.create = function () {};
+Model.alternate = function() {};
+
+module.exports = {
+  typeName: function () { return 'mock'; },
+  create: function() {},
+  read: function () {},
+  update: function () {},
+  destroy: function () {},
+  filters: function () {
+    return {
+      title: true
+    };
+  },
+  relations: function () {
+    return ['value'];
+  },
+  model: Model
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,4 @@
-describe('Endpoints', function () {
-  require('../modules/application/test');
-  require('../modules/controller/test');
-  require('../modules/formatter-jsonapi/test');
-  //require('../modules/source-memory/test');
-  require('../modules/source-bookshelf/test');
+describe('EndpointsAll', function () {
+  require('./unit');
+  require('./integration');
 });

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -1,0 +1,3 @@
+describe('Endpoints Integration', function () {
+  require('./json-api');
+});

--- a/test/integration/json-api/index.js
+++ b/test/integration/json-api/index.js
@@ -1,0 +1,3 @@
+describe('JSON-API', function () {
+  require('./v1');
+});

--- a/test/integration/json-api/v1/base-format/create/index.js
+++ b/test/integration/json-api/v1/base-format/create/index.js
@@ -1,0 +1,51 @@
+describe('creatingResources', function() {
+  it('must have a JSON object at the root of every response');
+  it('must not include any top-level members other than "data," "meta," or "links," "linked"');
+
+  it('should allow resources of a given type to be created');
+  it('must require a content-type header of application/vnd.api+json');
+  it('must require relevant extensions in the content-type header');
+  it('must require a single resource object as primary data');
+  it('must not allow partial updates');
+  it('must require a type member of the data');
+
+  describe('clientGeneratedIds', function() {
+    // A server MAY accept a client-generated ID along with a
+    // request to create a resource. An ID MUST be specified
+    // with an "id" key, the value of which MUST be a
+    // universally unique identifier. The client SHOULD use a
+    // properly generated and formatted UUID as described in RFC
+    // 4122 [RFC4122].
+    it('must return 403 Forbidden in response to an unsupported request using a client-generated ID');
+  });
+
+  describe('responses', function() {
+
+    describe('201Created', function() {
+      it('must respond to a successful resource creation');
+      it('must include a Location header identifying the location of the new resource');
+      it('must respond with 201 on a successful request if the request did not include a client-generated ID');
+      it('must include a document containing the primary resource created');
+      it('must make the self link and Location header the same');
+    });
+
+    describe('204NoContent', function() {
+      it('must respond with either 201 or 204 if the request included a client-generated ID');
+    });
+
+    describe('403Forbidden', function() {
+      it('should return 403 Forbidden in response to an unsupported creation request');
+    });
+
+    describe('409Conflict', function() {
+      it('must return 409 Conflict when processing a request to create a resource with an existing client-generated ID');
+      it('must return 409 Conflict when processing a request where the type does not match the endpoint');
+    });
+
+    describe('otherResponses', function() {
+      it('should use other HTTP codes to represent errors');
+      it('must interpret errors in accordance with HTTP semantics');
+      it('should return error details');
+    });
+  });
+});

--- a/test/integration/json-api/v1/base-format/delete/index.js
+++ b/test/integration/json-api/v1/base-format/delete/index.js
@@ -1,0 +1,27 @@
+describe('deletingResources', function() {
+  it('must have a JSON object at the root of every response');
+  it('must not include any top-level members other than "data," "meta," or "links," "linked"');
+
+  it('should allow existing resources to be deleted');
+  it('must require a content-type header of application/vnd.api+json');
+  it('must require relevant extensions in the content-type header');
+  it('must not allow partial updates');
+  it('should delete resources when a DELETE request is made to the resource URL');
+
+  describe('responses', function() {
+
+    describe('204NoContent', function() {
+      it('must return 204 No Content on a successful DELETE request');
+    });
+
+    describe('404NotFound', function() {
+      it('must return 404 Not Found when processing a request to delete a resource that does not exist');
+    });
+
+    describe('otherResponses', function() {
+      it('should use other HTTP codes to represent errors');
+      it('must interpret errors in accordance with HTTP semantics');
+      it('should return error details');
+    });
+  });
+});

--- a/test/integration/json-api/v1/base-format/errors/index.js
+++ b/test/integration/json-api/v1/base-format/errors/index.js
@@ -1,0 +1,14 @@
+describe('errors', function() {
+  it('must have a JSON object at the root of every response');
+  it('should return error objects that include additional information about problems encountered');
+  it('must return a collection keyed by "errors" in the top level of the response');
+  it('should not return errors with primary data');
+  it('should have an id member');
+  it('should have a href member with further details of the problem');
+  it('should have a status member representing the string value of an HTTP status code');
+  it('should have a code member representing an application-specific error code');
+  it('should have a title member representing a short summary of the problem');
+  it('should have a detail member representing a human-readable explanation of the problem');
+  it('should have a links member representing an array of pointers to the associated resources');
+  it('should have a paths member representing an array of pointers to the relevant attributes within the resource');
+});

--- a/test/integration/json-api/v1/base-format/index.js
+++ b/test/integration/json-api/v1/base-format/index.js
@@ -1,0 +1,7 @@
+describe('baseFormat', function() {
+  require('./read');
+  require('./create');
+  require('./update');
+  require('./delete');
+  require('./errors');
+});

--- a/test/integration/json-api/v1/base-format/read/index.js
+++ b/test/integration/json-api/v1/base-format/read/index.js
@@ -1,0 +1,142 @@
+const expect = require('chai').expect;
+
+const DB = require('../../../../../fixtures/classes/database');
+const authorController = require('../../../../../fixtures/controllers/authors');
+
+var req = require('../../../../../fixtures/mocks/express_request')();
+
+describe('read', function() {
+
+  before(function() {
+    return DB.reset();
+  });
+
+  describe('documentStructure', function() {
+
+    describe('topLevel', function() {
+      it('must respond to a successful request with an object', function() {
+        var authorRouteHandler = authorController.read({
+          responder: function(payload) {
+            expect(payload.code).to.equal(200);
+            expect(payload).to.be.an('object');
+          }
+        });
+        authorRouteHandler(req);
+      });
+      it('must respond to an unsuccessful request with a JSON object', function() {
+
+        DB.empty().then(function() {
+          var authorRouteHandler = authorController.read({
+            responder: function(payload) {
+              expect(payload.code).to.equal(400);
+              expect(payload).to.be.an('object');
+            }
+          });
+          authorRouteHandler({params:{}});
+        });
+      });
+      it('must place primary data under a top-level key named "data"');
+      it('must make primary data either a single resource object or an array of resource objects');
+      it('must not include any top-level members other than "data," "meta," or "links," "linked"');
+    });
+
+    describe('resourceObjects', function() {
+
+      describe('resourceAttributes', function() {
+        it('must not contain a foreign key as an attribute');
+        it('must include relations as linked resources');
+      });
+
+      describe('resourceIdentification', function() {
+        it('must have a unique type and id pair');
+      });
+
+      describe('resourceTypes', function() {
+        it('must contain a type');
+        it('must have a string value for type');
+      });
+
+      describe('resourceIds', function() {
+        it('must contain an id');
+        it('must have a string value for id');
+      });
+
+      describe('links', function() {
+        it('must have a json object as the value of any links key');
+      });
+
+      describe('resourceURLs', function() {
+        it('should include a URL in its links object keyed by "self" that identifies the resource represented by this object');
+        it('must respond to a get request to any `self` url with the resource as primary data');
+      });
+
+      describe('resourceRelationships', function() {
+        it('should contain references to related objects in the links object');
+        it('shall not have a relationship to another object keyed as "self"');
+        it('must be either a string URL or a link object');
+
+        describe('stringURLRelationship', function() {
+          it('should not change related URL even when the resource changes');
+        });
+
+        describe('linkObjectRelationship', function() {
+          it('must contain either a "self," "resource," "meta" property or an object linkage');
+          it('must express object linkages as type and id for to-one relationships');
+          it('must express object linkages as type and ids for to-many relationships');
+          it('must express object linkages as a data member whose value is an array of objects containing type and id for heterogeneous to-many relationships');
+          it('must include object linkage to resource objects included in the same compound document');
+        });
+      });
+    });
+
+    describe('compoundDocuments', function() {
+      it('should include linked resources');
+      it('must include linked resources as an array of resource objects in a top level `linked` member');
+      it('must not include more than one resource object for each type and id pair');
+    });
+
+    describe('metaInformation', function() {
+      // The document MAY be extended to include meta-information as
+      // "meta" members in several locations: at the top-level,
+      // within resource objects, and within link objects.
+      it('must be an object value');
+    });
+
+    describe('topLevelLinks', function() {
+      // it('should include a self link'); // superceded above
+      it('should include pagination links if necessary');
+    });
+  });
+
+  describe('inclusionOfLinkedResources', function() {
+    it('should include linked resources by default');
+    it('should support custom inclusion of linked resources based upon an include request parameter');
+    it('must not include other resource objects in the linked section when the client specifies an include parameter');
+    it('must have the identical relationship name as the key in the links section of the parent resource object');
+  });
+
+  describe('sparseFieldsets', function() {
+    it('should support returning only specific fields in the response on a per-type basis by including a fields[TYPE] parameter');
+    it('must not include other fields when the client specifies sparse fieldsets');
+  });
+
+  describe('sorting', function() {
+    it('should support requests to sort collections with a sort query parameter');
+    it('should support multiple sort criteria using comma-separated fields');
+    it('should sort multiple criteria in the order specified');
+    it('must sort ascending or descending based on explicit sort order using "+" or "-"');
+  });
+
+  describe('pagination', function() {
+    it('should limit the number of resources returned in a response to a subset of the whole set available');
+    it('should provide links to traverse a paginated data set');
+    it('must put any pagination links on the object that corresponds to a collection');
+    it('must only use "first," "last," "prev," and "next" as keys for pagination links');
+    it('must omit or set values to null for links that are unavailable');
+    it('must remain consistent with the sorting rules');
+  });
+
+  describe('filtering', function() {
+    it('must only use the filter query parameter for filtering data');
+  });
+});

--- a/test/integration/json-api/v1/base-format/update/index.js
+++ b/test/integration/json-api/v1/base-format/update/index.js
@@ -1,0 +1,99 @@
+describe('updatingResources', function() {
+  it('must have a JSON object at the root of every response');
+  it('must not include any top-level members other than "data," "meta," or "links," "linked"');
+
+  it('must require a single resource object as primary data');
+  it('should allow existing resources to be modified');
+  it('must require a content-type header of application/vnd.api+json');
+  it('must require relevant extensions in the content-type header');
+  it('must not allow partial updates');
+
+  describe('updatingResourceAttributes', function() {
+    it('should allow any or all attributes to be included in the resource object');
+    it('must interpret missing fields as their current values');
+    it('must not interpret missing fields as null values');
+  });
+
+  describe('updatingResourceToOneRelationships', function() {
+    it('must require to-One relationship links to be either an object with type and id or null');
+  });
+
+  describe('updatingResourceToManyRelationships', function() {
+    it('must require homogeneous to-Many relationship links to be an object with type and ids members');
+    it('must require heterogeneous to-Many relationship links to be an object with a data member containing an array of objects with type and id members');
+    it('should reject an attempt to do a full replacement of a to-many relationship');
+    it('must reject full-replacement atomically and with a 403 Forbidden response');
+  });
+
+  describe('responses', function() {
+
+    describe('204NoContent', function() {
+      it('must return 204 No Content on a successful update when attributes remain up-to-date');
+    });
+
+    describe('200Ok', function() {
+      it('must return 200 OK if it accepts the update but changes the resource in some way');
+      it('must include a representation of the updated resource on a 200 OK response');
+    });
+
+    describe('403Forbidden', function() {
+      it('must return 403 Forbidden on an unsupported request to update a resource or relationship');
+    });
+
+    describe('404NotFound', function() {
+      it('must return 404 Not Found when processing a request to modify a resource that does not exist');
+      it('must return 404 Not Found when processing a request that references a related resource that does not exist');
+    });
+
+    describe('409Conflict', function() {
+      it('should return 409 Conflict when processing an update that violates server-enforced constraints');
+      it('must return 409 Conflict when processing a request in which the type and id do not match the endpoint');
+    });
+
+    describe('otherResponses', function() {
+      it('should use other HTTP codes to represent errors');
+      it('must interpret errors in accordance with HTTP semantics');
+      it('should return error details');
+    });
+  });
+});
+
+describe('updatingRelationships', function() {
+  it('should respond to requests to links it sets as relationship URLs');
+
+  describe('updatingToOneRelationships', function() {
+    it('must respond to PUT request to a to-one relationship URL');
+    it('must require a top-level data member containing either an object with type and id members or null');
+    it('must return a 204 No Content on a successful PUT request');
+  });
+
+  describe('updatingToManyRelationships', function() {
+    it('must respond to PUT, POST, and DELETE requests to a to-many relationship URL');
+    it('must require a top-level data member containing either an object with type and id members or an array of such objects');
+    it('must completely replace every member of the relationship on a PUT request if allowed');
+    it('must return an appropriate error if some resources cannot be found or accessed');
+    it('must return a 403 Forbidden if complete replacement is not allowed by the server');
+    it('must append specified members of a POST request');
+    it('must not add existing type and id combinations again');
+    it('must return a 204 No Content if the resource is successfully added or already present');
+    it('must either DELETE members of the relationship or return 403 Forbidden on a DELETE request');
+    it('must return a 204 No Content if the resource is successfully deleted or is already missing');
+  });
+
+  describe('responses', function() {
+
+    describe('204NoContent', function() {
+      it('must return 204 No Content if the update is successful and the attributes remain up to date');
+    });
+
+    describe('403Forbidden', function() {
+      it('must return 403 Forbidden in response to an unsupported request to update a relationship');
+    });
+
+    describe('otherResponses', function() {
+      it('should use other HTTP codes to represent errors');
+      it('must interpret errors in accordance with HTTP semantics');
+      it('should return error details');
+    });
+  });
+});

--- a/test/integration/json-api/v1/extensions/bulk/index.js
+++ b/test/integration/json-api/v1/extensions/bulk/index.js
@@ -1,0 +1,25 @@
+describe('bulkExtension', function() {
+  it('should indicate support for the bulk extension by including the header Content-Type: application/vnd.api+json; ext=bulk in every response');
+  it('should allow the client to request the bulk extension by specifying the header Accept:application/vnd.api+json; ext=bulk');
+  it('must return 415 Unsupported if the client requests, but the server does not support the bulk extension');
+
+  describe('bulkOperations', function() {
+    it('must apply requests atomically');
+    it('must only succeed if all operations succeed');
+    it('must rollback all operations if any operation fails');
+  });
+
+  describe('creatingMultipleResources', function() {
+    it('must require an array of objects as primary data');
+    it('must require a type member in each object');
+  });
+
+  describe('updatingMultipleResources', function() {
+    it('must require an array of objects as primary data');
+    it('must require type and id in each object');
+  });
+
+  describe('deletingMultipleResources', function() {
+    it('must require a data member as an object with type and ids or an array of objects each with a type and id');
+  });
+});

--- a/test/integration/json-api/v1/extensions/index.js
+++ b/test/integration/json-api/v1/extensions/index.js
@@ -1,0 +1,31 @@
+describe('extensions', function () {
+
+  // The base JSON API specification MAY be extended to support
+  // additional capabilities.
+
+  it('should return supported extensions in the Content-Type header of every response');
+  it('must render supported extensions as a comma-separated list');
+
+  // Clients MAY request a particular media type extension by
+  // including its name in the ext media type parameter with the
+  // Accept header.
+
+  it('must not reject requests with supported media extensions in the Accept header');
+  it('must reject requests with unsupported media extensions in the Accept header with a 415 status');
+
+  describe('officialExtensions', function() {
+
+    require('./bulk');
+    require('./patch');
+
+  });
+
+  describe('customExtensions', function() {
+    it('should be specified using the ext media type parameter');
+    it('should have its ext media type be prefixed with a unique identifier for the organization');
+  });
+
+  describe('profiles', function() {
+    it('should be specified in the top-level meta object, keyped by profile');
+  });
+});

--- a/test/integration/json-api/v1/extensions/patch/index.js
+++ b/test/integration/json-api/v1/extensions/patch/index.js
@@ -1,0 +1,69 @@
+describe('patchExtension', function() {
+  it('should indicate support for the patch extension by including the header Content-Type application/vnd.api+json; ext=patch in every response');
+  it('should allow the client to request the patch extension by specifying the header Accept:application/vnd.api+json; ext=patch');
+  it('must return 415 Unsupported if the client requests, but the server does not support the patch extension');
+
+  describe('patchOperations', function() {
+    it('must require an array that conforms with JSON Patch format');
+    it('should limit type, order, and count of operations');
+
+    describe('requestURLsAndPatchPaths', function() {
+      it('must require the requestURL and operations "path" member to combine to target a particular resource, collection, attribute, or relationship');
+      it('must allow PATCH requests at any resource or relationship that accepts POST, PUT, or DELETE requests');
+      it('should allow PATCH requests at the root URL of the API');
+      it('must require each path in a PATCH operation at the root URL to include the full resource path relative to the rootURL');
+    });
+
+    describe('creatingResources', function() {
+      it('should create resources in a PATCH operation');
+    });
+
+    describe('updatingAttributes', function() {
+      it('should update attributes in a PATCH operation');
+    });
+
+    describe('updatingRelationships', function() {
+      it('should support relationship updates at a higher level');
+
+      describe('updatingToOneRelationships', function() {
+        it('should update to-one relationships in a PATCH operation');
+      });
+
+      describe('updatingToManyRelationships', function() {
+        it('should update to-many relationships in a PATCH operation');
+        it('must require a "value" member be an object that contains type and ids members or an array of objects with type and id members');
+        it('must completely replace every member of a relationship on a "replace" operation OR return 403 Forbidden if not allowed by the server');
+      });
+    });
+
+    describe('deletingResource', function() {
+      it('should delete resources in a PATCH operation');
+    });
+
+    describe('responses', function() {
+
+      describe('204NoContent', function() {
+        it('must return 204 No Content in a successful PATCH request in which the client\'s attributes remain up to date');
+      });
+
+      describe('200Ok', function() {
+        it('must return 200 OK if the server accepts the update but also changes the resources in other ways');
+        it('must include a representation of the updated resource');
+        it('must specify a Content-Type of application/json');
+        it('must contain an array of JSON objects in the body of the response');
+        it('must conform each JSON object to the JSON API media type');
+        it('must include JSON objects in sequential order corresponding to the operations in the request');
+      });
+
+      describe('otherResponses', function() {
+        it('should specify the most appropriate HTTP error code in each operation\'s response');
+        it('should stop processing PATCH operations when the first error is encountered');
+        it('should specify the most generally applicable HTTP code in the response');
+        it('should return error objects corresponding to each operation');
+        it('must contain an array of JSON objects in sequential order corresponding to the request');
+        it('should key response objects only on "errors" with no other top-level members');
+        it('should return appropriate error codes for each operation in the "status" member of each object');
+      });
+    });
+  });
+});

--- a/test/integration/json-api/v1/index.js
+++ b/test/integration/json-api/v1/index.js
@@ -1,0 +1,5 @@
+describe('v1', function () {
+  require('./base-format');
+  require('./extensions');
+  require('./recommendations');
+});

--- a/test/integration/json-api/v1/recommendations/index.js
+++ b/test/integration/json-api/v1/recommendations/index.js
@@ -1,0 +1,36 @@
+describe('recommendations', function() {
+
+  describe('naming', function() {
+    it('should use dasherized resource types');
+    it('should use dasherized attribute names');
+    it('should use dasherized association names');
+    it('should pluralize resource types');
+  });
+
+  describe('urlDesign', function() {
+
+    describe('referenceDocument', function() {
+      it('should have a reference document');
+    });
+
+    describe('urlsForResourceCollections', function() {
+      it('should form the URL for a collection from the resource type');
+    });
+
+    describe('urlsForIndividualResources', function() {
+      it('should form the URL for an individual resource by appending the ID to the collection URL');
+    });
+
+    describe('relationshipURLsAndRelatedResourceURLs', function() {
+      it('should form a relationshipURL by appending `/links/` and the name of the relationship to the resource URL');
+      it('should form a related resource URL by appending the name of the relationship to the resource URL');
+      it('should not use these relationship URLs as self links for the related resources');
+    });
+
+    describe('recommendationsForFiltering', function() {
+      it('should filter using query parameters that combine `filter` with the association name');
+      it('should allow multiple filter values in a comma-separated list');
+      it('should allow multiple filters in a single request');
+    });
+  });
+});

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,0 +1,7 @@
+describe('Endpoints', function () {
+  require('../../modules/application/test');
+  require('../../modules/controller/test');
+  require('../../modules/formatter-jsonapi/test');
+  //require('../../modules/source-memory/test');
+  require('../../modules/source-bookshelf/test');
+});


### PR DESCRIPTION
Includes a couple of sample tests, and a bunch of pending ones.
- Move unit tests to /test/unit
- Create `test-unit` and `test-integration` npm scripts
- Make `npm test` run both unit and integration tests
- Update fixtures as needed