### PR TITLE
remove foreign keys from json-api-formatted response

### DIFF
--- a/modules/formatter-jsonapi/index.js
+++ b/modules/formatter-jsonapi/index.js
@@ -21,10 +21,8 @@ module.exports = function (input, opts) {
     // determine which to-one relations on this model were not
     // explicitly included.
     var allRelations = model.constructor.relations;
-    var linkWithoutInclude = _.difference(
-      toOneRelations(model, allRelations),
-      linkWithInclude
-    );
+    var toOneRels = toOneRelations(model, allRelations);
+    var linkWithoutInclude = _.difference(Object.keys(toOneRels), linkWithInclude);
     // get the or initialize the primary resource key
     var primaryResource = getKey(output, 'data');
     // get a json representation of the model, excluding any related data
@@ -61,6 +59,11 @@ module.exports = function (input, opts) {
     serialized.id = String(serialized.id);
     // Include type on primary resource
     serialized.type = typeName;
+
+    // Remove foreign keys from model
+    for (var rel in toOneRels) {
+      delete serialized[toOneRels[rel]];
+    }
 
     if (Object.keys(links).length > 0) {
       serialized.links = links;

--- a/modules/formatter-jsonapi/lib/to_one_relations.js
+++ b/modules/formatter-jsonapi/lib/to_one_relations.js
@@ -8,6 +8,7 @@ module.exports = function (model, relations) {
     }
     // find related information about the model
     var relation = model.related(relationName);
+    var relKey = relation.relatedData.foreignKey;
     // if a relation is specified on the model that doesn't
     // actually exist, we should bail out quickly.
     if (!relation) {
@@ -17,8 +18,8 @@ module.exports = function (model, relations) {
     }
     // is this relation of a kind we care about? if yes, add it!
     if (relation.relatedData.type === 'belongsTo') {
-      result.push(relationName);
+      result[relationName] = relKey;
     }
     return result;
-  }, []);
+  }, {});
 };

--- a/modules/formatter-jsonapi/test/lib/to_one_relations.js
+++ b/modules/formatter-jsonapi/test/lib/to_one_relations.js
@@ -18,7 +18,7 @@ describe('toOneRelations', function () {
   });
 
   it('should return an array of to-one relations on a model', function () {
-    expect(toOneRelations(model, model.constructor.relations)).to.deep.equal(['author', 'series']);
+    expect(toOneRelations(model, model.constructor.relations)).to.deep.equal({'author': 'author_id', 'series': 'series_id'});
   });
 /*
   it('should ignore nested relations', function () {

--- a/test/fixtures/models/books.js
+++ b/test/fixtures/models/books.js
@@ -22,6 +22,9 @@ const classProps = {
     author_id: function (qb, value) {
       return qb.whereIn('author_id', value);
     },
+    series_id: function(qb, value) {
+      return qb.whereIn('series_id', value);
+    },
     date_published: function (qb, value) {
       return qb.whereIn('date_published', value);
     },

--- a/test/integration/json-api/v1/base-format/read/index.js
+++ b/test/integration/json-api/v1/base-format/read/index.js
@@ -81,8 +81,34 @@ describe('read', function() {
     describe('resourceObjects', function() {
 
       describe('resourceAttributes', function() {
-        it('must not contain a foreign key as an attribute');
-        it('must include relations as linked resources');
+        it('must not contain a foreign key as an attribute', function() {
+          var bookRouteHandler = bookController.read({
+            one:true,
+            responder: function(payload) {
+              expect(payload.code).to.equal(200);
+              expect(payload.data.data).to.be.an('object');
+              expect(payload.data.data).to.not.have.property('author_id');
+              expect(payload.data.data).to.not.have.property('series_id');
+            }
+          });
+          bookRouteHandler({params: {
+            id: 1
+          }});
+        });
+        it('must include relations as linked resources', function() {
+          var bookRouteHandler = bookController.read({
+            one:true,
+            responder: function(payload) {
+              expect(payload.code).to.equal(200);
+              expect(payload.data.data).to.be.an('object');
+              expect(payload.data.data.links).to.have.property('author');
+              expect(payload.data.data.links).to.have.property('series');
+            }
+          });
+          bookRouteHandler({params: {
+            id: 1
+          }});
+        });
       });
 
       describe('resourceIdentification', function() {


### PR DESCRIPTION
"Note: Although has-one foreign keys are often stored as columns in a database
alongside other fields, foreign keys MUST NOT be included in a resource's
attributes. All relations MUST be represented under a resource's links object,
as described below..."

https://github.com/dgeb/json-api/blob/v1rc2/format/index.md#resource-attributes-