### PR TITLE
Add type to all primary and linked resources

### DIFF
--- a/modules/controller/lib/responders/read.js
+++ b/modules/controller/lib/responders/read.js
@@ -43,7 +43,8 @@ module.exports = function (err, data, opts) {
     code: 200,
     data: jsonApi(data, {
       one: singleResult,
-      relations: relations
+      relations: relations,
+      typeName: opts.type
     })
   };
 };

--- a/test/integration/json-api/v1/base-format/read/index.js
+++ b/test/integration/json-api/v1/base-format/read/index.js
@@ -90,13 +90,57 @@ describe('read', function() {
       });
 
       describe('resourceTypes', function() {
-        it('must contain a type');
-        it('must have a string value for type');
+        it('must contain a type', function() {
+          var bookRouteHandler = bookController.read({
+            one:true,
+            responder: function(payload) {
+              expect(payload.code).to.equal(200);
+              expect(payload.data.data).to.have.property('type');
+            }
+          });
+          bookRouteHandler({params: {
+            id: 1
+          }});
+        });
+        it('must have a string value for type', function() {
+          var bookRouteHandler = bookController.read({
+            one:true,
+            responder: function(payload) {
+              expect(payload.code).to.equal(200);
+              expect(payload.data.data.type).to.be.a('string');
+            }
+          });
+          bookRouteHandler({params: {
+            id: 1
+          }});
+        });
       });
 
       describe('resourceIds', function() {
-        it('must contain an id');
-        it('must have a string value for id');
+        it('must contain an id', function() {
+          var bookRouteHandler = bookController.read({
+            one:true,
+            responder: function(payload) {
+              expect(payload.code).to.equal(200);
+              expect(payload.data.data).to.have.property('id');
+            }
+          });
+          bookRouteHandler({params: {
+            id: 1
+          }});
+        });
+        it('must have a string value for type', function() {
+          var bookRouteHandler = bookController.read({
+            one:true,
+            responder: function(payload) {
+              expect(payload.code).to.equal(200);
+              expect(payload.data.data.id).to.be.a('string');
+            }
+          });
+          bookRouteHandler({params: {
+            id: 1
+          }});
+        });
       });
 
       describe('links', function() {


### PR DESCRIPTION
- Ensure id is expressed as a string in the data

"Each resource object MUST contain a type member, whose value MUST be a string."
https://github.com/dgeb/json-api/blob/v1rc2/format/index.md#resource-types-

"Each resource object MUST contain an id member, whose value MUST be a string."
https://github.com/dgeb/json-api/blob/v1rc2/format/index.md#resource-ids-