### PR TITLE
Fix case where invalid relations are passed in include property

### DIFF
--- a/modules/controller/index.js
+++ b/modules/controller/index.js
@@ -11,9 +11,14 @@ function Controller(opts) {
   _.extend(this, parseOptions(opts));
 }
 
+Controller.prototype._isValidRelation = function(relation) {
+  var allowedRelations = this.source.relations();
+  return allowedRelations.indexOf(relation) !== -1;
+};
+
 Controller.prototype._filters = function (request) {
   var allowedFilters = Object.keys(this.source.filters());
-  return extract({
+  return this.validFilters(extract({
     context: request,
     contextKeysToSearch: this.requestKeysToSearch,
     // TODO: revisit this perhaps?
@@ -23,7 +28,7 @@ Controller.prototype._filters = function (request) {
     // on the underlying source.
     find: allowedFilters.concat(Object.keys(request.params)),
     normalizer: this.paramNormalizer
-  });
+  }));
 };
 
 Controller.prototype._relations = function (request) {
@@ -36,7 +41,22 @@ Controller.prototype._relations = function (request) {
   if (result && !Array.isArray(result)) {
     result = [result];
   }
-  return _.uniq(result);
+  return this.validRelations(_.uniq(result));
+};
+
+Controller.prototype.validFilters = function (filters) {
+  var allowedFilters = Object.keys(this.source.filters());
+  return Object.keys(filters).reduce(function (result, filter) {
+    if (allowedFilters.indexOf(filter) !== -1) {
+      result[filter] = filters[filter];
+    }
+    return result;
+  }, {});
+};
+
+Controller.prototype.validRelations = function(relations) {
+  var isValidRelation = this._isValidRelation.bind(this);
+  return relations.filter(isValidRelation);
 };
 
 Controller.prototype.responder = require('./lib/responder');
@@ -75,17 +95,27 @@ Controller.prototype.read = function (opts) {
   var type = source.typeName();
   var filters = this._filters.bind(this);
   var relations = this._relations.bind(this);
-  // allow a custom responder to receive the payload
+  var isValidRelation = this._isValidRelation.bind(this);
+  var includes = opts.include || [];
   var respond = opts.responder || this.responder;
+
+  // forEach instead of use validRelation() so that we get the exact bad actor
+  includes.forEach(function(relation) {
+    if (!isValidRelation(relation)) {
+      throw new Error('Model does not have relation "' + relation + '."');
+    }
+  });
+
   return function (request, response, next) {
-    var validRelations = relations(request).concat(opts.include || []);
+    var validRels = relations(request).concat(includes);
     source.read({
       filters: filters(request),
-      relations: validRelations
+      relations: validRels
     }, function (err, data) {
       var payload = readResponse(err, data, _.extend({}, opts, {
+        // FIXME: type is not used in readResponse
         type: type,
-        relations: validRelations
+        relations: validRels
       }));
       respond(payload, request, response, next);
     });

--- a/modules/source-bookshelf/index.js
+++ b/modules/source-bookshelf/index.js
@@ -24,23 +24,6 @@ function Source (opts) {
   }
 }
 
-Source.prototype._validFilters = function (request) {
-  var allowedFilters = Object.keys(this.filters());
-  return Object.keys(request).reduce(function (result, filter) {
-    if (allowedFilters.indexOf(filter) !== -1) {
-      result[filter] = request[filter];
-    }
-    return result;
-  }, {});
-};
-
-Source.prototype._validRelations = function (request) {
-  var allowedRelations = this.relations();
-  return request.filter(function (relation) {
-    return allowedRelations.indexOf(relation) !== -1;
-  });
-};
-
 Source.prototype._find = function (params, opts, cb) {
   return this.model.filter(params).fetch(opts).exec(cb);
 };
@@ -79,8 +62,8 @@ Source.prototype.read = function (opts, cb) {
   if (!opts) {
     opts = {};
   }
-  var filters = this._validFilters(opts.filters || {});
-  var relations = this._validRelations(opts.relations || []);
+  var filters = opts.filters || {};
+  var relations = opts.relations || [];
   return this._find(filters, { withRelated: relations }, cb);
 };
 


### PR DESCRIPTION
Relations were validated by Source.prototype.read(), but unvalidated relations
were passed into read responder. This fix uses validated relations from data in
read responder instead of unvalidated options.