### PR TITLE
Make update and create conform to json-api resource structure

### DIFF
--- a/modules/controller/index.js
+++ b/modules/controller/index.js
@@ -78,7 +78,7 @@ Controller.prototype.create = function (opts) {
   }
 
   return function (request, response) {
-    source.create(request.body[type], opts, function (err, data) {
+    source.create(request.body.data, opts, function (err, data) {
       var payload = createResponse(err, data, _.extend({}, opts, {
         type: type
       }));
@@ -144,7 +144,7 @@ Controller.prototype.update = function (opts) {
         return respond(lookupFailed, request, response);
       }
       return source.update(
-        request.body[type],
+        request.body.data,
         _.extend({model:model}, opts),
         function (err, data) {
           var payload = updateResponse(err, data, _.extend({}, opts, {

--- a/modules/controller/lib/responders/create.js
+++ b/modules/controller/lib/responders/create.js
@@ -1,8 +1,9 @@
+const jsonApi = require('../../../formatter-jsonapi');
+
 module.exports = function (err, data, opts) {
   if (!opts) {
     opts = {};
   }
-  var type = opts.type;
 
   if (err) {
     return {
@@ -16,12 +17,10 @@ module.exports = function (err, data, opts) {
     };
   }
 
-  // scope result to type for json-api compliance
-  var result = {};
-  result[type] = data;
-
   return {
     code: 201,
-    data: result
+    data: jsonApi(data, {
+      typeName: opts.type
+    })
   };
 };

--- a/modules/controller/lib/responders/update.js
+++ b/modules/controller/lib/responders/update.js
@@ -1,8 +1,9 @@
+const jsonApi = require('../../../formatter-jsonapi');
+
 module.exports = function (err, data, opts) {
   if (!opts) {
     opts = {};
   }
-  var type = opts.type;
 
   if (err) {
     return {
@@ -16,12 +17,10 @@ module.exports = function (err, data, opts) {
     };
   }
 
-  // scope result to type for json-api compliance
-  var result = {};
-  result[type] = data;
-
   return {
     code: 200,
-    data: result
+    data: jsonApi(data, {
+      typeName: opts.type
+    })
   };
 };

--- a/modules/controller/test/lib/responders/create.js
+++ b/modules/controller/test/lib/responders/create.js
@@ -1,19 +1,40 @@
 const expect = require('chai').expect;
 
+const BookshelfSource = require('../../../../source-bookshelf');
+const BooksModel = require('../../../../../test/fixtures/models/books');
+const BooksSource = new BookshelfSource({
+  model: BooksModel
+});
+const DB = require('../../../../../test/fixtures/classes/database');
+
 const create = require('../../../lib/responders/create');
 
 describe('create', function () {
 
-  it('should return scoped data and code 201 when there are no errors', function () {
+  beforeEach(function () {
+    return DB.reset();
+  });
+
+  it('should return scoped data and code 201 when there are no errors', function (done) {
     var opts = {
       type: 'type'
     };
-    var data = {
-      key: 'value'
-    };
-    var result = create(null, data, opts);
-    expect(result.code).to.equal(201);
-    expect(result.data[opts.type]).to.equal(data);
+    // We're passing everything through the formatter now. That requires
+    // a Bookshelf model.
+    BooksSource.create({
+      author_id:1,
+      title: 'test book',
+      date_published: '2015-02-01'
+    }, {method: 'create'}, function(err, book) {
+      var result = create(null, book, opts);
+      var flatBook = book.toJSON();
+      expect(result.code).to.equal(201);
+      expect(result.data.data.id).to.equal(String(flatBook.id));
+      expect(result.data.data.title).to.equal(flatBook.title);
+      expect(result.data.data.type).to.equal('type');
+      expect(result.data.data.date_published).to.equal(flatBook.date_published);
+      done();
+    });
   });
 
   it('should return errors and code 422 when there is an error', function () {

--- a/modules/controller/test/lib/responders/update.js
+++ b/modules/controller/test/lib/responders/update.js
@@ -1,19 +1,41 @@
 const expect = require('chai').expect;
 
+const BookshelfSource = require('../../../../source-bookshelf');
+const BooksModel = require('../../../../../test/fixtures/models/books');
+const BooksSource = new BookshelfSource({
+  model: BooksModel
+});
+const DB = require('../../../../../test/fixtures/classes/database');
+
 const update = require('../../../lib/responders/update');
 
 describe('update', function () {
 
-  it('should return scoped data and code 200 when there are no errors', function () {
+  beforeEach(function () {
+    return DB.reset();
+  });
+
+  it('should return scoped data and code 200 when there are no errors', function (done) {
     var opts = {
       type: 'type'
     };
-    var data = {
-      key: 'value'
-    };
-    var result = update(null, data, opts);
-    expect(result.code).to.equal(200);
-    expect(result.data[opts.type]).to.equal(data);
+    // We're passing everything through the formatter now. That requires
+    // a Bookshelf model. This unit doesn't actually update anything: we
+    // just want a handy model, so we're going to create one.
+    BooksSource.create({
+      author_id:1,
+      title: 'test book',
+      date_published: '2015-02-01'
+    }, {method: 'create'}, function(err, book) {
+      var result = update(null, book, opts);
+      var flatBook = book.toJSON();
+      expect(result.code).to.equal(200);
+      expect(result.data.data.id).to.equal(String(flatBook.id));
+      expect(result.data.data.title).to.equal(flatBook.title);
+      expect(result.data.data.type).to.equal('type');
+      expect(result.data.data.date_published).to.equal(flatBook.date_published);
+      done();
+    });
   });
 
   it('should return errors and code 422 when there is an error', function () {

--- a/modules/formatter-jsonapi/index.js
+++ b/modules/formatter-jsonapi/index.js
@@ -1,94 +1,34 @@
-const _ = require('lodash');
-
-const getKey = require('./lib/get_key');
-const toOneRelations = require('./lib/to_one_relations');
-const link = require('./lib/link');
+const formatModel = require('./lib/format_model');
 
 // Take an array of Bookshelf models and convert them into a
 // json-api compliant representation of the underlying data.
 module.exports = function (input, opts) {
-  // get the relations we'll be pulling off the input data
-  var linkWithInclude = opts.relations || [];
-  // cache if we are looking for a single item
-  var singleResult = opts.one;
-  // initialize an index so we can prevent serializing the same records
-  // more than once to the top level `linked` key.
-  var linkedResourceIndex = {};
-  // get the underlying model type so we know what the primary resource is
-  var typeName = opts.typeName;
-  // iterate through the input, adding links and populating linked data
-  var result = input.reduce(function (output, model) {
-    // determine which to-one relations on this model were not
-    // explicitly included.
-    var allRelations = model.constructor.relations;
-    var toOneRels = toOneRelations(model, allRelations);
-    var linkWithoutInclude = _.difference(Object.keys(toOneRels), linkWithInclude);
-    // get the or initialize the primary resource key
-    var primaryResource = getKey(output, 'data');
-    // get a json representation of the model, excluding any related data
-    var serialized = model.toJSON({shallow:true});
-    // build a links object, adding any linked models to
-    var links = link(model, {
-      linkWithInclude: linkWithInclude,
-      linkWithoutInclude: linkWithoutInclude,
-      exporter: function (models, type) {
-        var shallowModel;
-        // get a reference to the array of linked resources of this type
-        var linkedResource = getKey(output.linked, type);
-        // get the index of ids for this resource type
-        var index = getKey(linkedResourceIndex, type);
-        // iterate each of the linked resources
-        models.forEach(function (model) {
-          // cache the model's ID
-          var id = model.get('id');
-          // only add the linked resource if it doesn't already exist.
-          if (id && index.indexOf(id) === -1) {
-            shallowModel = model.toJSON({shallow:true});
-            // json-api requires id be a string -- shouldn't rely on server
-            shallowModel.id = String(shallowModel.id);
-            // Include type on linked resources
-            shallowModel.type = model.typeName;
-            linkedResource.push(model.toJSON({shallow:true}));
-            index.push(id);
-          }
-        });
-      }
-    });
+  var formatted = {linked:{}};
+  var isSingle = !input.length;
 
-    // json-api requires id be a string -- shouldn't rely on server
-    serialized.id = String(serialized.id);
-    // Include type on primary resource
-    serialized.type = typeName;
-
-    // Remove foreign keys from model
-    for (var rel in toOneRels) {
-      delete serialized[toOneRels[rel]];
-    }
-
-    if (Object.keys(links).length > 0) {
-      serialized.links = links;
-    }
-    // add the model to the primary resource key
-    primaryResource.push(serialized);
-    // return the output we have built up so far
-    return output;
-  }, {linked:{}});
-
+  if (isSingle) {
+    formatModel(formatted, input, opts);
+  } else {
+    // iterate through the input, adding links and populating linked data
+    input.reduce(function(output, model) {
+      return formatModel(output, model, opts);
+    }, formatted);
+  }
   // if there is no linked data, don't include it.
-  if (Object.keys(result.linked).length === 0) {
-    delete result.linked;
+  if (Object.keys(formatted.linked).length === 0) {
+    delete formatted.linked;
   }
 
   // if we were looking for a single result, return it as an object
-  if (singleResult && input.length === 1) {
-    result.data = result.data[0];
+  if ((opts.one && input.length === 1) || isSingle) {
+    formatted.data = formatted.data[0];
   }
 
   // if there is nothing in the root object, represent it as an empty array
-  if (!result.data) {
-    result.data = [];
+  if (!formatted.data) {
+    formatted.data = [];
   }
 
   // bam.  done.
-  return result;
+  return formatted;
 };

--- a/modules/formatter-jsonapi/lib/format_model.js
+++ b/modules/formatter-jsonapi/lib/format_model.js
@@ -1,0 +1,66 @@
+const _ = require('lodash');
+
+const toOneRelations = require('./to_one_relations');
+const getKey = require('./get_key');
+const link = require('./link');
+
+module.exports = function formatModel(output, model, opts) {
+  // determine which to-one relations on this model were not
+  // explicitly included.
+  var allRelations = model.constructor.relations;
+  var toOneRels = toOneRelations(model, allRelations);
+  // get the or initialize the primary resource key
+  var primaryResource = getKey(output, 'data');
+  // get a json representation of the model, excluding any related data
+  var serialized = model.toJSON({shallow:true});
+  // get the relations we'll be pulling off the input data
+  var linkWithInclude = opts.relations || [];
+  var linkWithoutInclude = _.difference(Object.keys(toOneRels), linkWithInclude);
+  // get the underlying model type so we know what the primary resource is
+  var typeName = opts.typeName;
+  // build a links object, adding any linked models to
+  var links = link(model, {
+    linkWithInclude: linkWithInclude,
+    linkWithoutInclude: linkWithoutInclude,
+    exporter: function (models, type) {
+      var shallowModel;
+      // get a reference to the array of linked resources of this type
+      var linkedResource = getKey(output.linked, type);
+      // get the index of ids for this resource type
+      var index = getKey({}, type);
+      // iterate each of the linked resources
+      models.forEach(function (model) {
+        // cache the model's ID
+        var id = model.get('id');
+        // only add the linked resource if it doesn't already exist.
+        if (id && index.indexOf(id) === -1) {
+          shallowModel = model.toJSON({shallow:true});
+          // json-api requires id be a string -- shouldn't rely on server
+          shallowModel.id = String(shallowModel.id);
+          // Include type on linked resources
+          shallowModel.type = model.typeName;
+          linkedResource.push(model.toJSON({shallow:true}));
+          index.push(id);
+        }
+      });
+    }
+  });
+
+  // json-api requires id be a string -- shouldn't rely on server
+  serialized.id = String(serialized.id);
+  // Include type on primary resource
+  serialized.type = typeName;
+
+  // Remove foreign keys from model
+  for (var rel in toOneRels) {
+    delete serialized[toOneRels[rel]];
+  }
+
+  if (Object.keys(links).length > 0) {
+    serialized.links = links;
+  }
+  // add the model to the primary resource key
+  primaryResource.push(serialized);
+  // return the output we have built up so far
+  return output;
+};

--- a/modules/formatter-jsonapi/test/index.js
+++ b/modules/formatter-jsonapi/test/index.js
@@ -9,6 +9,7 @@ describe('jsonApi', function () {
     require('./lib/link');
     require('./lib/relate');
     require('./lib/to_one_relations');
+    require('./lib/format_model');
   });
 
   describe('module', function () {

--- a/modules/formatter-jsonapi/test/lib/format_model.js
+++ b/modules/formatter-jsonapi/test/lib/format_model.js
@@ -1,0 +1,41 @@
+const expect = require('chai').expect;
+
+const BookshelfSource = require('../../../source-bookshelf');
+const BooksModel = require('../../../../test/fixtures/models/books');
+const BooksSource = new BookshelfSource({
+  model: BooksModel
+});
+const DB = require('../../../../test/fixtures/classes/database');
+
+const formatModel = require('../../lib/format_model');
+
+describe('formatModel', function () {
+
+  beforeEach(function () {
+    return DB.reset();
+  });
+
+  it('should return an array scoped to "data" when there are no errors', function (done) {
+    var opts = {
+      typeName: 'type'
+    };
+    // We're passing everything through the formatter now. That requires
+    // a Bookshelf model.
+    BooksSource.create({
+      author_id:1,
+      title: 'test book',
+      date_published: '2015-02-01'
+    }, {method: 'create'}, function(err, book) {
+      var seed = {linked:{}};
+      var formatted = formatModel(seed, book, opts);
+      var flatBook = book.toJSON();
+      expect(seed.data).to.be.an('Array');
+      expect(seed.data[0].id).to.equal(String(flatBook.id));
+      expect(seed.data[0].title).to.equal(flatBook.title);
+      expect(seed.data[0].type).to.equal('type');
+      expect(seed.data[0].date_published).to.equal(flatBook.date_published);
+      expect(seed).to.eql(formatted);
+      done();
+    });
+  });
+});

--- a/modules/source-bookshelf/lib/base_methods.js
+++ b/modules/source-bookshelf/lib/base_methods.js
@@ -38,6 +38,7 @@ exports.addCreate = function (source) {
 
 exports.addUpdate = function (source) {
   source.model.prototype.update = function (params) {
+    delete params.type;
     return this.save(params, {patch: true});
   };
 };

--- a/modules/source-bookshelf/test/index.js
+++ b/modules/source-bookshelf/test/index.js
@@ -75,6 +75,7 @@ describe('BookshelfSource', function () {
           title: 'test book',
           date_published: '2015-02-01'
         }, { method: 'create' }, function (err, book) {
+          expect(book).to.be.an.instanceof(BooksModel);
           BooksSource.read(null, function (findNewErr, allBooksPlusNew) {
             expect(totalBooks + 1).to.equal(allBooksPlusNew.length);
             done();
@@ -134,11 +135,10 @@ describe('BookshelfSource', function () {
       BooksSource.byId(1, function (findErr, bookOne) {
         BooksSource.update({
           title: 'altered book'
-        }, { method: 'update', model: bookOne }, function () {
-          BooksSource.byId(1, function (err, book) {
-            expect(book.get('title')).to.equal(newTitle);
-            done();
-          });
+        }, { method: 'update', model: bookOne }, function (err, data) {
+          expect(data).to.be.an.instanceof(BooksModel);
+          expect(data.get('title')).to.equal(newTitle);
+          done();
         });
       });
     });

--- a/test/integration/json-api/v1/base-format/update/index.js
+++ b/test/integration/json-api/v1/base-format/update/index.js
@@ -1,5 +1,35 @@
+const expect = require('chai').expect;
+
+const DB = require('../../../../../fixtures/classes/database');
+const authorController = require('../../../../../fixtures/controllers/authors');
+
 describe('updatingResources', function() {
-  it('must have a JSON object at the root of every response');
+
+  beforeEach(function() {
+    return DB.reset();
+  });
+
+  it('must have a JSON object at the root of every response', function(done) {
+    var authorRouteHandler = authorController.update({
+      responder: function(payload) {
+        expect(payload.code).to.equal(200);
+        expect(payload.data.data).to.be.an('object');
+        done();
+      }
+    });
+    authorRouteHandler({
+      params: {
+        id: 1
+      },
+      body: {
+        data: {
+          type: 'authors',
+          id: 1,
+          name: 'tiddlywinks'
+        }
+      }
+    });
+  });
   it('must not include any top-level members other than "data," "meta," or "links," "linked"');
 
   it('must require a single resource object as primary data');


### PR DESCRIPTION
- move request and response data under "data" key instead of type key
- parse update and create responses through json-formatter
- update unit tests for create and update to use real models
- add integration test for update because i needed it to find a bug in the
unit tests

fixes #24