### PR TITLE
Make linked object a single array of all linked relations, regardless of type

### DIFF
--- a/modules/formatter-jsonapi/index.js
+++ b/modules/formatter-jsonapi/index.js
@@ -3,7 +3,7 @@ const formatModel = require('./lib/format_model');
 // Take an array of Bookshelf models and convert them into a
 // json-api compliant representation of the underlying data.
 module.exports = function (input, opts) {
-  var formatted = {linked:{}};
+  var formatted = {linked:[]};
   var isSingle = !input.length;
 
   if (isSingle) {

--- a/modules/formatter-jsonapi/lib/format_model.js
+++ b/modules/formatter-jsonapi/lib/format_model.js
@@ -20,6 +20,7 @@ module.exports = function formatModel(output, model, opts) {
   var toManyWithoutInclude = _.difference(linkWithoutInclude, toOneWithoutInclude);
   // get the underlying model type so we know what the primary resource is
   var typeName = opts.typeName;
+  var linkedIndex = {};
   // build a links object, adding any linked models to
   var links = link(model, {
     linkWithInclude: linkWithInclude,
@@ -28,10 +29,8 @@ module.exports = function formatModel(output, model, opts) {
     primaryType: typeName,
     exporter: function (models, type) {
       var shallowModel;
-      // get a reference to the array of linked resources of this type
-      var linkedResource = getKey(output.linked, type);
       // get the index of ids for this resource type
-      var index = getKey({}, type);
+      var index = getKey(linkedIndex, type);
       // iterate each of the linked resources
       models.forEach(function (model) {
         // cache the model's ID
@@ -42,8 +41,8 @@ module.exports = function formatModel(output, model, opts) {
           // json-api requires id be a string -- shouldn't rely on server
           shallowModel.id = String(shallowModel.id);
           // Include type on linked resources
-          shallowModel.type = model.typeName;
-          linkedResource.push(model.toJSON({shallow:true}));
+          shallowModel.type = type;
+          output.linked.push(shallowModel);
           index.push(id);
         }
       });

--- a/modules/formatter-jsonapi/lib/link.js
+++ b/modules/formatter-jsonapi/lib/link.js
@@ -34,7 +34,7 @@ module.exports = function (model, opts) {
     var type = relatedData.target.typeName;
     var link = {
       type: relatedData.target.typeName,
-      id: id
+      id: String(id)
     };
     if (id) {
       link.href = '/' + type + '/' + id;
@@ -64,7 +64,7 @@ module.exports = function (model, opts) {
       // and should serialize to an `ids` key rather than the `id`
       // key
       link.ids = related.reduce(function (result, model) {
-        var id = model.get('id');
+        var id = String(model.id);
         // exclude nulls and duplicates, the point of a links
         // entry is to provide linkage to related resources,
         // not a full mapping of the underlying data
@@ -78,7 +78,7 @@ module.exports = function (model, opts) {
       }
     } else {
       // for singular resources, store the id under `id`
-      link.id = related.get('id') || null;
+      link.id = String(related.id || null);
       if (exporter) {
         exporter([related], type);
       }

--- a/modules/formatter-jsonapi/test/lib/link.js
+++ b/modules/formatter-jsonapi/test/lib/link.js
@@ -12,7 +12,7 @@ const Authors = require('../../../../test/fixtures/models/authors');
 describe('link', function () {
 
   var booksModel, authorsModel;
-  var booksByAuthorOne = _.chain(fantasyDatabase.books).filter({author_id:1}).pluck('id').value();
+  var booksByAuthorOne = _.chain(fantasyDatabase.books).filter({author_id:1}).pluck('id').map(function(i) {return String(i);}).value();
 
   before(function () {
     return DB.reset().then(function () {
@@ -56,7 +56,7 @@ describe('link', function () {
     })).to.deep.equal({
       author: {
         href: '/authors/1',
-        id: 1,
+        id: '1',
         type: 'authors'
       }
     });
@@ -67,7 +67,7 @@ describe('link', function () {
       toOneWithoutInclude: ['series']
     })).to.deep.equal({
       series: {
-        id: null,
+        id: 'null',
         type: 'series'
       }
     });

--- a/test/integration/json-api/v1/base-format/read/index.js
+++ b/test/integration/json-api/v1/base-format/read/index.js
@@ -359,7 +359,6 @@ describe('read', function() {
                   (linkedAuthor.type && linkedAuthor.id);
 
                 expect(payload.code).to.equal(200);
-                expect(payload.data.linked).to.have.property('authors');
                 expect(objectLinkage).to.exist;
                 done();
               }
@@ -428,8 +427,32 @@ describe('read', function() {
     });
 
     describe('compoundDocuments', function() {
-      it('should include linked resources');
-      it('must include linked resources as an array of resource objects in a top level `linked` member');
+      // Covered above in relations object linkages tests
+      // it('should include linked resources', function() {});
+      it('must include linked resources as an array of resource objects in a top level `linked` member', function(done) {
+        var bookRouteHandler = bookController.read({
+          one:true,
+          responder: function(payload) {
+            var linkedAuthor = payload.data.data.links.author;
+            expect(payload.code).to.equal(200);
+            expect(payload.data.linked).to.not.have.property('authors');
+            expect(payload.data.linked[0].type).to.equal(linkedAuthor.type);
+            expect(payload.data.linked[0].id).to.equal(linkedAuthor.id);
+            done();
+          }
+        });
+        bookRouteHandler({
+          params: {
+            id: 1
+          },
+          query: {
+            include: 'author'
+          }
+        });
+      });
+
+      // To test this at the integration level, we need some nested
+      // relations pointing to the same resources
       it('must not include more than one resource object for each type and id pair');
     });
 
@@ -439,7 +462,6 @@ describe('read', function() {
     // });
 
     describe('topLevelLinks', function() {
-      // it('should include a self link'); // superceded above
       it('should include pagination links if necessary');
     });
   });


### PR DESCRIPTION
Also:

- Made model index lookup an object outside of exporter closure
- Fixed instances of sending linked model ids as a number instead of a string