### PR TITLE
fix linked array to only return unique values

### DIFF
--- a/modules/formatter-jsonapi/index.js
+++ b/modules/formatter-jsonapi/index.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 const formatModel = require('./lib/format_model');
 
 // Take an array of Bookshelf models and convert them into a
@@ -14,6 +16,12 @@ module.exports = function (input, opts) {
       return formatModel(output, model, opts);
     }, formatted);
   }
+
+  // limit the linked array to unique type/id combinations
+  formatted.linked = _.uniq(formatted.linked, function(rel) {
+    return rel.type + rel.id;
+  });
+
   // if there is no linked data, don't include it.
   if (Object.keys(formatted.linked).length === 0) {
     delete formatted.linked;

--- a/modules/formatter-jsonapi/lib/format_model.js
+++ b/modules/formatter-jsonapi/lib/format_model.js
@@ -20,7 +20,6 @@ module.exports = function formatModel(output, model, opts) {
   var toManyWithoutInclude = _.difference(linkWithoutInclude, toOneWithoutInclude);
   // get the underlying model type so we know what the primary resource is
   var typeName = opts.typeName;
-  var linkedIndex = {};
   // build a links object, adding any linked models to
   var links = link(model, {
     linkWithInclude: linkWithInclude,
@@ -30,20 +29,18 @@ module.exports = function formatModel(output, model, opts) {
     exporter: function (models, type) {
       var shallowModel;
       // get the index of ids for this resource type
-      var index = getKey(linkedIndex, type);
       // iterate each of the linked resources
       models.forEach(function (model) {
         // cache the model's ID
         var id = model.id;
         // only add the linked resource if it doesn't already exist.
-        if (id && index.indexOf(id) === -1) {
+        if (id) {
           shallowModel = model.toJSON({shallow:true});
           // json-api requires id be a string -- shouldn't rely on server
           shallowModel.id = String(shallowModel.id);
           // Include type on linked resources
           shallowModel.type = type;
           output.linked.push(shallowModel);
-          index.push(id);
         }
       });
     }

--- a/test/integration/json-api/v1/base-format/read/index.js
+++ b/test/integration/json-api/v1/base-format/read/index.js
@@ -451,9 +451,21 @@ describe('read', function() {
         });
       });
 
-      // To test this at the integration level, we need some nested
-      // relations pointing to the same resources
-      it('must not include more than one resource object for each type and id pair');
+      it('must not include more than one resource object for each type and id pair', function(done) {
+        var bookRouteHandler = bookController.read({
+          responder: function(payload) {
+            expect(payload.code).to.equal(200);
+            expect(payload.data.linked.length).to.equal(2);
+            done();
+          }
+        });
+        bookRouteHandler({
+          params: {},
+          query: {
+            include: 'author'
+          }
+        });
+      });
     });
 
     // Not currently used by endpoints


### PR DESCRIPTION
- exporter function didn't maintain state of index object
- why do it ourselves?
- instead run `_.uniq()` on collection before returning