### PR TITLE
include location header on successful create

### DIFF
--- a/modules/controller/lib/payloads/create.js
+++ b/modules/controller/lib/payloads/create.js
@@ -5,6 +5,8 @@ module.exports = function (err, data, opts) {
     opts = {};
   }
 
+  var typeName = opts.type;
+
   if (err) {
     return {
       code: err.httpStatus || 422,
@@ -20,7 +22,10 @@ module.exports = function (err, data, opts) {
   return {
     code: 201,
     data: jsonApi(data, {
-      typeName: opts.type
-    })
+      typeName: typeName
+    }),
+    headers: {
+      location: '/' + typeName + '/' + data.id
+    }
   };
 };

--- a/modules/controller/lib/responder.js
+++ b/modules/controller/lib/responder.js
@@ -10,9 +10,15 @@ module.exports = function (payload, request, response, next) {
   }
   var code = payload.code;
   var data = payload.data;
+  var headers = payload.headers;
   var isExpress = !!response.send;
   var isHapi = !!response.request;
   var contentType = 'application/vnd.api+json';
+  if (headers) {
+    Object.keys(headers).forEach(function(header) {
+      response.set(header, headers[header]);
+    });
+  }
   if (!isExpress && !isHapi) {
     throw new Error('Unsupported server type!');
   }

--- a/modules/controller/test/lib/responder.js
+++ b/modules/controller/test/lib/responder.js
@@ -75,4 +75,24 @@ describe('responder', function () {
     expect(stubReturn.code.calledWith(payload.code)).to.be.true;
   });
 
+  it('should include headers described in the payload', function() {
+    var payload = {
+      code: 201,
+      data: {},
+      headers: {
+        location: '/foos/1'
+      }
+    };
+    var request = {
+      accepts: sinon.stub().returns(false)
+    };
+    var response = {
+      set: sinon.stub().returnsThis(),
+      status: sinon.stub().returnsThis(),
+      send: sinon.stub().returnsThis()
+    };
+    responder(payload, request, response);
+    expect(response.set.calledWith('location', payload.headers.location)).to.be.true;
+  });
+
 });

--- a/test/integration/json-api/v1/base-format/create/index.js
+++ b/test/integration/json-api/v1/base-format/create/index.js
@@ -37,7 +37,6 @@ describe('creatingResources', function() {
   it('must respond to a successful request with an object', function(done) {
     var bookRouteHandler = bookController.create({
       responder: function(payload) {
-        expect(payload.code).to.equal(201);
         expect(payload.data).to.be.an('object');
         done();
       }
@@ -61,24 +60,9 @@ describe('creatingResources', function() {
     var allowedTopLevel = ['data', 'linked', 'links', 'meta'];
     var bookRouteHandler = bookController.create({
       responder: function(payload) {
-        expect(payload.code).to.equal(201);
         Object.keys(payload.data).forEach(function(key) {
           expect(allowedTopLevel).to.contain(key);
         });
-        done();
-      }
-    });
-    bookRouteHandler(createReq);
-  });
-
-  it('should allow resources of a given type to be created', function(done) {
-    var bookRouteHandler = bookController.create({
-      responder: function(payload) {
-        var data = payload.data.data;
-        expect(payload.code).to.equal(201);
-        expect(data).to.have.property('id');
-        expect(data.date_published).to.equal(createReq.body.data.date_published);
-        expect(data.title).to.equal(createReq.body.data.title);
         done();
       }
     });
@@ -113,11 +97,59 @@ describe('creatingResources', function() {
   describe('responses', function() {
 
     describe('201Created', function() {
-      it('must respond to a successful resource creation');
-      it('must include a Location header identifying the location of the new resource');
-      it('must respond with 201 on a successful request if the request did not include a client-generated ID');
-      it('must include a document containing the primary resource created');
-      it('must make the self link and Location header the same');
+      it('must respond to a successful resource creation', function(done) {
+        var bookRouteHandler = bookController.create({
+          responder: function(payload) {
+            expect(payload.code).to.equal(201);
+            done();
+          }
+        });
+        bookRouteHandler(createReq);
+      });
+
+      it('must include a Location header identifying the location of the new resource', function(done) {
+        var bookRouteHandler = bookController.create({
+          responder: function(payload) {
+            expect(payload.headers.location).to.equal('/books/' + payload.data.data.id);
+            done();
+          }
+        });
+        bookRouteHandler(createReq);
+      });
+
+      it('must respond with 201 on a successful request if the request did not include a client-generated ID', function(done) {
+        var bookRouteHandler = bookController.create({
+          responder: function(payload) {
+            expect(payload.code).to.equal(201);
+            done();
+          }
+        });
+        bookRouteHandler(createReq);
+      });
+
+      it('must include a document containing the primary resource created', function(done) {
+        var bookRouteHandler = bookController.create({
+          responder: function(payload) {
+            var data = payload.data.data;
+            expect(payload.code).to.equal(201);
+            expect(data).to.have.property('id');
+            expect(data.date_published).to.equal(createReq.body.data.date_published);
+            expect(data.title).to.equal(createReq.body.data.title);
+            done();
+          }
+        });
+        bookRouteHandler(createReq);
+      });
+
+      it('must make the self link and Location header the same', function(done) {
+        var bookRouteHandler = bookController.create({
+          responder: function(payload) {
+            expect(payload.headers.location).to.equal(payload.data.data.links.self);
+            done();
+          }
+        });
+        bookRouteHandler(createReq);
+      });
     });
 
     describe('204NoContent', function() {


### PR DESCRIPTION
done by allowing payload responders to declare payload specific to their
methods (e.g. location header in a create response)