### PR TITLE
Sparse fieldset integration tests

### DIFF
--- a/modules/controller/lib/configure_controller.js
+++ b/modules/controller/lib/configure_controller.js
@@ -29,7 +29,7 @@ module.exports = function (method, source, opts) {
     typeName: source.typeName(),
     include: [],
     filter: {},
-    //fields: {},
+    fields: {},
     sort: []
   };
   var config = _.defaults({}, opts, defaults);

--- a/modules/source-bookshelf/index.js
+++ b/modules/source-bookshelf/index.js
@@ -82,6 +82,10 @@ Source.prototype.read = function (opts) {
     qb = processFilter(model, qb, opts.filter);
     qb = processSort(self, qb, opts.sort);
   }).fetch({
+
+    // adding this in the queryBuilder changes the qb, but fetch still
+    // returns all columns
+    columns: opts.fields ? opts.fields[self.typeName()] : undefined,
     withRelated: _.intersection(this.relations(), opts.include || [])
   }).then(function (result) {
     result.sourceOpts = opts;

--- a/test/integration/json-api/v1/base-format/delete/index.js
+++ b/test/integration/json-api/v1/base-format/delete/index.js
@@ -70,7 +70,6 @@ describe('deletingResources', function() {
           bookController.read({
             responder: function(payload) {
               var secondRead = payload.data;
-              console.log(secondRead);
               expect(secondRead.data.length).to.equal(firstRead.data.length - 1);
               expect(_.pluck(secondRead.data, 'id').indexOf(destroyReq.params.id)).to.equal(-1);
               done();

--- a/test/integration/json-api/v1/base-format/read/index.js
+++ b/test/integration/json-api/v1/base-format/read/index.js
@@ -518,8 +518,19 @@ describe('read', function() {
     });
 
     describe('sparseFieldsets', function() {
-      it('should support returning only specific fields in the response on a per-type basis by including a fields[TYPE] parameter');
-      it('must not include other fields when the client specifies sparse fieldsets');
+      it('should support returning **only** specific fields in the response on a per-type basis by including a fields[TYPE] parameter', function(done) {
+        var bookRouteHandler = bookController.read({
+          responder: function(payload) {
+            var dataObj = payload.data.data[0];
+            expect(dataObj).to.have.property('id');
+            expect(dataObj).to.have.property('title');
+            expect(dataObj).to.not.have.property('date_published');
+            done();
+          }
+        });
+        readReq.query = { fields: {books: 'id,title'} };
+        bookRouteHandler(readReq);
+      });
     });
 
     describe('sorting', function() {


### PR DESCRIPTION
This implements sparse fieldsets for the main model only. Punting on nested sparse fieldsets.

I previously wrote a lib that worked like `process_sort` and `process_filter` to add a `columns`, constraint to the queryBuilder. That worked using either Knex's `.select()` or `.columns()`, but Bookshelf's `collection.fetch()` still returned all columns contrary to the note under [`fetch()`](http://bookshelfjs.org/#Collection-fetch). The only thing that works is passing a columns option into `fetch()`.