### PR TITLE
Add support for reading nested relationship links

### DIFF
--- a/modules/controller/lib/get_nested_relations.js
+++ b/modules/controller/lib/get_nested_relations.js
@@ -1,0 +1,17 @@
+module.exports = function getNestedRelations(model, rel) {
+  var relatedModels;
+
+  if (model.models) {
+    relatedModels = model.models.reduce(function(collection, model) {
+      return collection.add(model.related(rel.shift()));
+    });
+  } else {
+    relatedModels = model.related(rel.shift());
+  }
+
+  if (rel.length === 0) {
+    return relatedModels;
+  } else {
+    return getNestedRelations(relatedModels, rel);
+  }
+};

--- a/modules/controller/lib/source/read_relation.js
+++ b/modules/controller/lib/source/read_relation.js
@@ -1,17 +1,20 @@
 const throwIfNoModel = require('../throw_if_no_model');
+const getNestedRelations = require('../get_nested_relations');
 
 module.exports = function(source, opts, request) {
   var relation = request.params.relation || null;
   return source.byId(request.params.id, relation).
     then(throwIfNoModel).
     then(function (model) {
-      var result = model.related(relation);
+      var result = getNestedRelations(model, relation.split('.'));
+
+      // opts.typeName at the moment is the source type NOT the related type.
       if (result.length) {
-        // opts.typeName at the moment is the sourceType NOT the related type.
         opts.typeName = result.models[0].constructor.typeName;
       } else {
         opts.typeName = result.constructor.typeName;
       }
+
       result.sourceOpts = opts;
       return result;
     });

--- a/test/fixtures/models/books.js
+++ b/test/fixtures/models/books.js
@@ -47,7 +47,8 @@ const classProps = {
     'author',
     'series',
     'stores',
-    'author.books'
+    'author.books',
+    'stores.books'
   ]
 };
 

--- a/test/integration/json-api/v1/base-format/read/index.js
+++ b/test/integration/json-api/v1/base-format/read/index.js
@@ -362,7 +362,31 @@ describe('read', function() {
           bookRouteHandler(readReq);
         });
 
-        it('should return related resources as the response primary data when a nested string URL is fetched');
+        it('should return related resources as the response primary data when a nested string URL through a to-One is fetched', function(done) {
+          // /books/1/author.books
+          readReq.params.relation = 'author.books';
+          var bookRouteHandler = bookController.readRelation({
+            responder: function(payload) {
+              expect(payload.data.data.length).to.equal(4);
+              expect(payload.data.data[0].type).to.equal('books');
+              done();
+            }
+          });
+          bookRouteHandler(readReq);
+        });
+
+        it('should return related resources as the response primary data when a nested string URL through a to-Many is fetched', function(done) {
+          // /books/1/stores.books
+          readReq.params.relation = 'stores.books';
+          var bookRouteHandler = bookController.readRelation({
+            responder: function(payload) {
+              expect(payload.data.data.length).to.equal(11);
+              expect(payload.data.data[0].type).to.equal('books');
+              done();
+            }
+          });
+          bookRouteHandler(readReq);
+        });
 
         describe('stringURLRelationship', function() {
           // TODO: implement


### PR DESCRIPTION
- recursively settle nested model collections in readRelation
- untested at greater level, but could potentially support infinitely-nested
  relations (e.g. /books/1/stores.books.author.books)
- add integration tests for the basic cases (e.g. toOne/toMany and
  toMany/toOne)