### PR TITLE
make tests pass

### DIFF
--- a/test/integration/json-api/v1/base-format/create/index.js
+++ b/test/integration/json-api/v1/base-format/create/index.js
@@ -209,16 +209,14 @@ describe('creatingResources', function() {
             };
             bookController.read({
               responder: function(payload) {
-                // halp
-                console.log(JSON.stringify(payload, false, 2));
                 var readResult = payload.data;
-                var payloadData = readResult.data[0];
+                var payloadData = readResult.data;
                 var payloadLinks = payloadData.links;
                 var createData = createReq.body.data;
-                var createLinks = createReq.body.data.links;
+                var createLinks = createData.links;
 
                 expect(readResult.included.length).to.equal(1);
-                expect(readResult.included[0].id).to.equal(createData.links.stores.id[0]);
+                expect(readResult.included[0].id).to.equal(createLinks.stores.id[0]);
                 expect(payloadData.title).to.equal(createData.title);
                 expect(payloadData.date_published).to.equal(createData.date_published);
                 expect(payloadLinks.author.id).to.equal(createLinks.author.id);

--- a/test/integration/json-api/v1/base-format/delete/index.js
+++ b/test/integration/json-api/v1/base-format/delete/index.js
@@ -62,7 +62,8 @@ describe('deletingResources', function() {
       var readReq = {
         headers: {
           'accept': 'application/vnd.api+json'
-        }
+        },
+        params:{}
       };
       var bookRouteHandler = bookController.destroy({
         responder: function(payload) {

--- a/test/integration/json-api/v1/base-format/update/index.js
+++ b/test/integration/json-api/v1/base-format/update/index.js
@@ -156,7 +156,7 @@ describe('updatingResources', function() {
           bookController.read({
             responder: function(payload) {
               var secondRead = payload.data;
-              var payloadData = secondRead.data[0];
+              var payloadData = secondRead.data;
               var payloadLinks = payloadData.links;
               var updateLinks = updateData.links;
 
@@ -191,8 +191,8 @@ describe('updatingResources', function() {
           bookController.read({
             responder: function(payload) {
               var secondRead = payload.data;
-              var secondReadData = secondRead.data[0];
-              var firstReadData = firstRead.data[0];
+              var secondReadData = secondRead.data;
+              var firstReadData = firstRead.data;
               expect(secondRead.included).to.deep.equal(firstRead.included);
               expect(secondReadData.title).to.not.equal(firstReadData.title);
               expect(secondReadData.date_published).to.equal(firstReadData.date_published);
@@ -240,7 +240,7 @@ describe('updatingResources', function() {
 
           bookController.read({
             responder: function(payload) {
-              var payloadLinks = payload.data.data[0].links;
+              var payloadLinks = payload.data.data.links;
               var updateLinks = updateData.links;
               expect(payloadLinks.author.id).to.equal(updateLinks.author.id);
               expect(payloadLinks.series.id).to.equal(updateLinks.series.id);
@@ -278,7 +278,7 @@ describe('updatingResources', function() {
 
           bookController.read({
             responder: function(payload) {
-              var payloadLinks = payload.data.data[0].links;
+              var payloadLinks = payload.data.data.links;
               // var updateLinks = updateData.links;
               expect(payloadLinks.series.id).to.equal('null');
               done();
@@ -323,7 +323,7 @@ describe('updatingResources', function() {
           bookController.read({
             responder: function(payload) {
               var secondRead = payload.data;
-              var payloadLinks = secondRead.data[0].links;
+              var payloadLinks = secondRead.data.links;
               var updateLinks = updateData.links;
 
               expect(secondRead.included.length).to.equal(2);
@@ -366,7 +366,7 @@ describe('updatingResources', function() {
           bookController.read({
             responder: function(payload) {
               var secondRead = payload.data;
-              var payloadLinks = secondRead.data[0].links;
+              var payloadLinks = secondRead.data.links;
               var updateLinks = updateData.links;
 
               expect(secondRead).to.not.have.property('included');


### PR DESCRIPTION
Issue in create/update was tests were testing for response as an array, which I believe was incorrect. Your code sent a single object (I think correctly), which broke the tests.

Fixed a couple of smaller test issues:
- Caching objects correctly in create
- Sending empty params in delete