### PR TITLE
json-api rc3 resource relationships

### DIFF
--- a/modules/adapter-bookshelf/index.js
+++ b/modules/adapter-bookshelf/index.js
@@ -257,6 +257,8 @@ Adapter.prototype.read = function (opts, mode) {
       columns: fields,
       withRelated: _.intersection(self.relations(), opts.include || [])
     }).then(function (result) {
+      // This is a lot of gross in order to pass this data into the
+      // formatter later. Need to formalize this in some other way.
       result.mode = mode;
       result.relations = opts.include;
       result.singleResult = singleResult;

--- a/modules/adapter-bookshelf/index.js
+++ b/modules/adapter-bookshelf/index.js
@@ -138,7 +138,7 @@ Adapter.prototype.typeName = function () {
 
   @returns {Promise(Bookshelf.Model)|Promise(Bookshelf.Collection)} related models.
 */
-Adapter.prototype.related = function (opts, relation, model) {
+Adapter.prototype.related = function (opts, relation, mode, model) {
   var related = relate(model, relation);
   var relatedModel, relatedIds;
   if (related.models) {
@@ -147,6 +147,14 @@ Adapter.prototype.related = function (opts, relation, model) {
   } else {
     relatedModel = related.constructor;
     relatedIds = related.id;
+  }
+
+  if (mode === 'relation') {
+    opts.baseType = this.typeName();
+    opts.baseId = model.id;
+    opts.baseRelation = relation;
+    opts.fields = {};
+    opts.fields[related.constructor.typeName] = ['id', 'type'];
   }
 
   // @todo fix this
@@ -162,7 +170,7 @@ Adapter.prototype.related = function (opts, relation, model) {
 
   return new this.constructor({
     model: relatedModel
-  }).read(opts, 'related');
+  }).read(opts, mode);
 };
 
 /**
@@ -218,7 +226,7 @@ Adapter.prototype.read = function (opts, mode) {
   var model = this.model;
   var ready = bPromise.resolve();
   var singleResult = mode === 'single' ||
-    (mode === 'related' && !Array.isArray(opts.filter.id));
+    ((mode === 'related' || mode === 'relation') && !Array.isArray(opts.filter.id));
 
   // populate the field listing for a table so we know which columns
   // we can use for sparse fieldsets.
@@ -249,8 +257,12 @@ Adapter.prototype.read = function (opts, mode) {
       columns: fields,
       withRelated: _.intersection(self.relations(), opts.include || [])
     }).then(function (result) {
+      result.mode = mode;
       result.relations = opts.include;
       result.singleResult = singleResult;
+      result.baseType = opts.baseType;
+      result.baseId = opts.baseId;
+      result.baseRelation = opts.baseRelation;
       return result;
     });
   });

--- a/modules/adapter-bookshelf/lib/destructure_request_data.js
+++ b/modules/adapter-bookshelf/lib/destructure_request_data.js
@@ -18,7 +18,7 @@ module.exports = function(model, params) {
       }
 
       var fkey;
-      var relation = relations[key];
+      var relation = relations[key].linkage;
       var relatedData = model.related(key).relatedData;
       var relationType = relatedData.type;
 
@@ -42,7 +42,7 @@ module.exports = function(model, params) {
 
       // toMany relations
       if (relationType === 'belongsToMany' || relationType === 'hasMany') {
-        return bPromise.map(relations[key], function(rel) {
+        return bPromise.map(relation, function(rel) {
           return relatedData.target.collection().query(function(qb) {
             return qb.where({id:rel.id});
           }).fetchOne().then(function(model) {
@@ -54,7 +54,7 @@ module.exports = function(model, params) {
         }).then(function() {
           toManyRels.push({
             name: key,
-            id: _.pluck(relations[key], 'id')
+            id: _.pluck(relation, 'id')
           });
           return params;
         });

--- a/modules/adapter-bookshelf/lib/destructure_request_data.js
+++ b/modules/adapter-bookshelf/lib/destructure_request_data.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const bPromise = require('bluebird');
 const Kapow = require('kapow');
 const sanitizeRequestData = require('./sanitize_request_data');
@@ -41,19 +42,19 @@ module.exports = function(model, params) {
 
       // toMany relations
       if (relationType === 'belongsToMany' || relationType === 'hasMany') {
-        return bPromise.map(relations[key].id, function(id) {
+        return bPromise.map(relations[key], function(rel) {
           return relatedData.target.collection().query(function(qb) {
-            return qb.where({id:id});
+            return qb.where({id:rel.id});
           }).fetchOne().then(function(model) {
             if (model === null) {
-              throw Kapow(404, 'Unable to find relation "' + key + '" with id ' + id);
+              throw Kapow(404, 'Unable to find relation "' + key + '" with id ' + rel.id);
             }
             return params;
           });
         }).then(function() {
           toManyRels.push({
             name: key,
-            id: relations[key].id
+            id: _.pluck(relations[key], 'id')
           });
           return params;
         });

--- a/modules/formatter-jsonapi/lib/link.js
+++ b/modules/formatter-jsonapi/lib/link.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 const relate = require('./relate');
 
 module.exports = function (model, opts) {
@@ -58,14 +60,15 @@ module.exports = function (model, opts) {
         // if the related is an array, we have a hasMany relation
         link.linkage = related.reduce(function (result, model) {
           var id = String(model.id);
+          var linkObject = {
+            id: id,
+            type: relatedType
+          };
           // exclude nulls and duplicates, the point of a links
           // entry is to provide linkage to related resources,
           // not a full mapping of the underlying data
-          if (id && result.indexOf(id) === -1) {
-            result.push({
-              id: id,
-              type: relatedType
-            });
+          if (id && !_.findWhere(result, linkObject)) {
+            result.push(linkObject);
           }
           return result;
         }, []);

--- a/modules/formatter-jsonapi/lib/link.js
+++ b/modules/formatter-jsonapi/lib/link.js
@@ -6,91 +6,96 @@ module.exports = function (model, opts) {
   }
   var links = {};
   var primaryType = model.constructor.typeName;
-  var toOneWithoutIncludes = opts.toOneWithoutInclude || [];
-  var toManyWithoutIncludes = opts.toManyWithoutInclude || [];
+  var linkWithoutIncludes = opts.linkWithoutInclude || [];
   var linkWithIncludes = opts.linkWithInclude || [];
   var exporter = opts.exporter;
+  var topLevelLinker = opts.topLevelLinker;
 
-  // To-one link relations that were not explictly included. For
-  // example, a record in a database of employees might look like this:
-  // {
-  //   "id": "1",
-  //   "name": "tyler",
-  //   "position_id": "1"
-  // }
-  // The output of that record in json-api notation would be:
-  // {
-  //   "id": "1",
-  //   "name": "tyler",
-  //   "links": {
-  //     "type": "position",
-  //     "id": "1"
-  //   }
-  // }
-  toOneWithoutIncludes.reduce(function (result, relationName) {
-    var relation = model.related(relationName);
-    var relatedData = relation.relatedData;
-    var fkey = relatedData.foreignKey;
-    var id = model.get(fkey);
-    var type = relatedData.target.typeName;
-    var link = {
-      type: relatedData.target.typeName,
-      id: String(id)
-    };
-    if (id) {
-      link.resource = '/' + type + '/' + id;
-    }
-    result[relationName] = link;
-    return result;
-  }, links);
+  if (topLevelLinker) {
+    links.self = '/' + opts.baseType + '/' + opts.baseId + '/links/' + opts.baseRelation;
+    links.related = '/' + opts.baseType + '/' + opts.baseId + '/' + opts.baseRelation;
+    topLevelLinker(links);
+  } else {
 
-  // To-many link relations that were not explicitly included.
-  // Added to `links` as a string URL reference
-  toManyWithoutIncludes.reduce(function (result, relationName) {
-    var link = '/' + primaryType + '/' + model.id + '/' + relationName;
-    result[relationName] = link;
-    return result;
-  }, links);
+    // To-one link relations that were not explictly included. For
+    // example, a record in a database of employees might look like this:
+    // {
+    //   "id": "1",
+    //   "name": "tyler",
+    //   "position_id": "1"
+    // }
+    // The output of that record in json-api notation would be:
+    // {
+    //   "id": "1",
+    //   "name": "tyler",
+    //   "links": {
+    //     "self": "/employees/1/links/position",
+    //     "related": "/employees/1/position"
+    //   }
+    // }
+    linkWithoutIncludes.reduce(function (result, relationName) {
+      var id = model.id;
+      var link = {
+        self: '/' + primaryType + '/' + id + '/links/' + relationName,
+        related: '/' + primaryType + '/' + id + '/' + relationName
+      };
+      result[relationName] = link;
+      return result;
+    }, links);
 
-  // Link relations that were explictly included, adding the associated
-  // resources to the top level "included" object
-  linkWithIncludes.reduce(function (result, relationName) {
-    var related = relate(model, relationName);
-    var type = related.model ? related.model.typeName : related.constructor.typeName;
-    var link = {
-      type: type
-    };
+    // Link relations that were explictly included, adding the associated
+    // resources to the top level "included" object
+    linkWithIncludes.reduce(function (result, relationName) {
+      var id = model.id;
+      var related = relate(model, relationName);
+      var relatedType = related.model ? related.model.typeName : related.constructor.typeName;
+      var link = {
+        self: '/' + primaryType + '/' + id + '/links/' + relationName,
+        related: '/' + primaryType + '/' + id + '/' + relationName
+      };
 
-    if (related.models) {
-      // if the related is an array, we have a hasMany relation
-      link.id = related.reduce(function (result, model) {
-        var id = String(model.id);
-        // exclude nulls and duplicates, the point of a links
-        // entry is to provide linkage to related resources,
-        // not a full mapping of the underlying data
-        if (id && result.indexOf(id) === -1) {
-          result.push(id);
+      if (related.models) {
+        // if the related is an array, we have a hasMany relation
+        link.linkage = related.reduce(function (result, model) {
+          var id = String(model.id);
+          // exclude nulls and duplicates, the point of a links
+          // entry is to provide linkage to related resources,
+          // not a full mapping of the underlying data
+          if (id && result.indexOf(id) === -1) {
+            result.push({
+              id: id,
+              type: relatedType
+            });
+          }
+          return result;
+        }, []);
+        if (exporter) {
+          related.forEach(function (model) {
+            exporter(model);
+          });
         }
-        return result;
-      }, []);
-      if (exporter) {
-        related.forEach(function (model) {
-          exporter(model, type);
-        });
+      } else {
+        // for singular resources
+        if (related.id) {
+          link.linkage = {
+            type: relatedType,
+            id: String(related.id)
+          };
+        } else {
+          link.linkage = 'null';
+        }
+        if (exporter) {
+          exporter(related);
+        }
       }
-    } else {
-      // for singular resources
-      link.id = String(related.id || null);
-      if (exporter) {
-        exporter(related, type);
-      }
-    }
-    result[relationName] = link;
-    return result;
-  }, links);
+      result[relationName] = link;
+      return result;
+    }, links);
 
-  // always add a self-referential link
-  links.self = '/' + primaryType + '/' + model.id;
+    // always add a self-referential link
+    links.self = '/' + primaryType + '/' + model.id;
+  }
+
 
   return links;
 };

--- a/modules/formatter-jsonapi/test/lib/link.js
+++ b/modules/formatter-jsonapi/test/lib/link.js
@@ -31,15 +31,25 @@ describe('link', function () {
   });
 
   it('should generate links object for a model', function () {
-    expect(link(authorsModel, {
-      linkWithInclude: ['books'],
-    })).to.deep.equal({
+    var result = {
       books: {
-        type: 'books',
-        id: booksByAuthorOne
+        self: '/authors/1/links/books',
+        related: '/authors/1/books',
       },
       self: '/authors/1'
-    });
+    };
+
+    result.books.linkage = _.reduce(booksByAuthorOne, function(res, authorId) {
+      res.push({
+        id: authorId,
+        type: 'books'
+      });
+      return res;
+    }, []);
+
+    expect(link(authorsModel, {
+      linkWithInclude: ['books'],
+    })).to.deep.equal(result);
   });
 
   it('should call exporter for each included model', function () {
@@ -53,12 +63,11 @@ describe('link', function () {
 
   it('should generate toOne links entries for a model', function () {
     expect(link(booksModel, {
-      toOneWithoutInclude: ['author'],
+      linkWithoutInclude: ['author'],
     })).to.deep.equal({
       author: {
-        resource: '/authors/1',
-        id: '1',
-        type: 'authors'
+        self: '/books/11/links/author',
+        related: '/books/11/author'
       },
       self: '/books/11'
     });
@@ -66,11 +75,11 @@ describe('link', function () {
 
   it('should handle null toOne link entries for a model', function () {
     expect(link(booksModel, {
-      toOneWithoutInclude: ['series']
+      linkWithoutInclude: ['series']
     })).to.deep.equal({
       series: {
-        id: 'null',
-        type: 'series'
+        self: '/books/11/links/series',
+        related: '/books/11/series'
       },
       self: '/books/11'
     });

--- a/modules/request-handler/index.js
+++ b/modules/request-handler/index.js
@@ -147,15 +147,11 @@ RequestHandler.prototype.read = function (request) {
   var id = params.id;
 
   var related, findRelated;
-  if (mode === RELATED_MODE) {
-    related = params.related;
-    findRelated = adapter.related.bind(adapter, query, related);
-    return adapter.byId(id, related).then(throwIfNoModel).then(findRelated);
-  }
 
-  // var relation, findRelation;
-  if (mode === RELATION_MODE) {
-    throw new Error('not implemented');
+  if (mode === RELATED_MODE || mode === RELATION_MODE) {
+    related = params.related || params.relation;
+    findRelated = adapter.related.bind(adapter, query, related, mode);
+    return adapter.byId(id, related).then(throwIfNoModel).then(findRelated);
   }
 
   if (id) {

--- a/modules/request-handler/index.js
+++ b/modules/request-handler/index.js
@@ -175,6 +175,7 @@ RequestHandler.prototype.update = function (request) {
 
   if (relation) {
     data = {
+      id: id,
       type: adapter.typeName(),
       links: {}
     };

--- a/modules/request-handler/index.js
+++ b/modules/request-handler/index.js
@@ -179,7 +179,7 @@ RequestHandler.prototype.update = function (request) {
       type: adapter.typeName(),
       links: {}
     };
-    data.links[relation] = request.body.data;
+    data.links[relation] = {linkage: request.body.data};
   }
 
   return adapter.byId(id).

--- a/modules/request-handler/lib/verify_data_object.js
+++ b/modules/request-handler/lib/verify_data_object.js
@@ -2,18 +2,28 @@ const _ = require('lodash');
 const Kapow = require('kapow');
 
 module.exports = function(request, endpoint) {
-  var err, type, id;
+  var err, isValidType, id;
   var data = request.body.data;
 
-  if (!_.isPlainObject(data)) {
-    err = Kapow(400, 'Primary data must be a single object.');
+  if (!_.isPlainObject(data) && !_.isArray(data)) {
+    err = Kapow(400, 'Primary data must be a single object or array.');
     return err;
   }
 
-  type = data.type;
+  if (_.isArray(data)) {
+    isValidType = _.reduce(data, function(isValid, resource) {
+      if (!resource.type || typeof resource.type !== 'string') {
+        isValid = false;
+      }
+      return isValid;
+    }, true);
+  } else {
+    isValidType = typeof data.type === 'string';
+  }
+
   id = request.params && request.params.id;
 
-  if (typeof type !== 'string') {
+  if (!isValidType) {
     err = Kapow(400, 'Primary data must include a type.');
     return err;
   }

--- a/modules/response-formatter/lib/read.js
+++ b/modules/response-formatter/lib/read.js
@@ -15,7 +15,11 @@ module.exports = function (formatter, config, data) {
     code: '200',
     data: formatter(data, {
       singleResult: data.singleResult,
-      relations: data.relations
+      relations: data.relations,
+      mode: data.mode,
+      baseType: data.baseType,
+      baseId: data.baseId,
+      baseRelation: data.baseRelation
     })
   };
 };

--- a/test/app/src/modules/authors/routes.js
+++ b/test/app/src/modules/authors/routes.js
@@ -20,7 +20,7 @@ module.exports = {
       schema: schema,
       validators: validateJsonSchema
     }),
-    '/:id/:relation': controller.update()
+    '/:id/links/:relation': controller.update()
   },
   delete: {
     '/:id': controller.destroy()

--- a/test/app/src/modules/books/routes.js
+++ b/test/app/src/modules/books/routes.js
@@ -20,7 +20,7 @@ module.exports = {
       schema: schema,
       validators: validateJsonSchema
     }),
-    '/:id/:relation': controller.update()
+    '/:id/links/:relation': controller.update()
   },
   delete: {
     '/:id': controller.destroy()

--- a/test/app/src/modules/chapters/routes.js
+++ b/test/app/src/modules/chapters/routes.js
@@ -20,7 +20,7 @@ module.exports = {
       schema: schema,
       validators: validateJsonSchema
     }),
-    '/:id/:relation': controller.update()
+    '/:id/links/:relation': controller.update()
   },
   delete: {
     '/:id': controller.destroy()

--- a/test/app/src/modules/series/routes.js
+++ b/test/app/src/modules/series/routes.js
@@ -20,7 +20,7 @@ module.exports = {
       schema: schema,
       validators: validateJsonSchema
     }),
-    '/:id/:relation': controller.update()
+    '/:id/links/:relation': controller.update()
   },
   delete: {
     '/:id': controller.destroy()

--- a/test/app/src/modules/stores/routes.js
+++ b/test/app/src/modules/stores/routes.js
@@ -20,7 +20,7 @@ module.exports = {
       schema: schema,
       validators: validateJsonSchema
     }),
-    '/:id/:relation': controller.update()
+    '/:id/links/:relation': controller.update()
   },
   delete: {
     '/:id': controller.destroy()

--- a/test/integration/json-api/v1/base-format/create/index.js
+++ b/test/integration/json-api/v1/base-format/create/index.js
@@ -14,7 +14,9 @@ describe('creatingResources', function() {
       links: {
         author: {type: 'authors', id: '1'},
         series: {type: 'series', id: '1'},
-        stores: {type: 'stores', id: ['1']}
+        stores: [
+          {type: 'stores', id: '1'}
+        ]
       }
     };
     return Fixture.reset();
@@ -176,13 +178,12 @@ describe('creatingResources', function() {
                 var readResult = res.body;
                 var payloadData = readResult.data;
                 var payloadLinks = payloadData.links;
-
                 expect(readResult.included.length).to.equal(3);
                 expect(payloadData.title).to.equal(bookData.title);
                 expect(payloadData.date_published).to.equal(bookData.date_published);
                 expect(payloadLinks.author.linkage.id).to.equal(bookData.links.author.id);
                 expect(payloadLinks.series.linkage.id).to.equal(bookData.links.series.id);
-                expect(payloadLinks.stores.linkage[0].id).to.deep.equal(bookData.links.stores.id[0]);
+                expect(payloadLinks.stores.linkage[0].id).to.equal(bookData.links.stores[0].id);
               });
           });
       });

--- a/test/integration/json-api/v1/base-format/create/index.js
+++ b/test/integration/json-api/v1/base-format/create/index.js
@@ -12,11 +12,11 @@ describe('creatingResources', function() {
       'title': 'The Lost Book of Tolkien',
       'date_published': '2015-02-17',
       links: {
-        author: {type: 'authors', id: '1'},
-        series: {type: 'series', id: '1'},
-        stores: [
+        author: {linkage: {type: 'authors', id: '1'}},
+        series: {linkage: {type: 'series', id: '1'}},
+        stores: {linkage: [
           {type: 'stores', id: '1'}
-        ]
+        ]}
       }
     };
     return Fixture.reset();
@@ -101,38 +101,29 @@ describe('creatingResources', function() {
         });
     });
 
-    // Pending https://github.com/endpoints/endpoints/issues/51
-    it.skip('must return 403 Forbidden in response to an unsupported request using a client-generated ID');
+    // TODO: Pending https://github.com/endpoints/endpoints/issues/51
+    it('must return 403 Forbidden in response to an unsupported request using a client-generated ID');
   });
 
   describe('responses', function() {
 
     describe('201Created', function() {
-      it('must respond to a successful resource creation', function() {
-        return Agent.request('POST', '/books')
-          .send({ data: bookData })
-          .promise()
-          .then(function(res) {
-            expect(res.status).to.equal(201);
-          });
-      });
-
       // This test currently fails, location isn't correct.
-      it.skip('must include a Location header identifying the location of the new resource', function() {
+      it('must include a Location header identifying the location of the new resource', function() {
         return Agent.request('POST', '/books')
           .send({ data: bookData })
           .promise()
           .then(function(res) {
             var location = res.headers.location;
             var book = res.body.data;
-            var expectedLocation = Agent.baseUrl + '/books/' + book.id;
+            var expectedLocation = '/books/' + book.id;
 
             expect(location).to.equal(expectedLocation);
           });
       });
 
       // This seems like a complete dupe of two tests ago
-      it.skip('must respond with 201 on a successful request if the request did not include a client-generated ID', function() {
+      it('must respond with 201 on a successful request if the request did not include a client-generated ID', function() {
         return Agent.request('POST', '/books')
           .send({ data: bookData })
           .promise()
@@ -181,9 +172,9 @@ describe('creatingResources', function() {
                 expect(readResult.included.length).to.equal(3);
                 expect(payloadData.title).to.equal(bookData.title);
                 expect(payloadData.date_published).to.equal(bookData.date_published);
-                expect(payloadLinks.author.linkage.id).to.equal(bookData.links.author.id);
-                expect(payloadLinks.series.linkage.id).to.equal(bookData.links.series.id);
-                expect(payloadLinks.stores.linkage[0].id).to.equal(bookData.links.stores[0].id);
+                expect(payloadLinks.author.linkage.id).to.equal(bookData.links.author.linkage.id);
+                expect(payloadLinks.series.linkage.id).to.equal(bookData.links.series.linkage.id);
+                expect(payloadLinks.stores.linkage[0].id).to.equal(bookData.links.stores.linkage[0].id);
               });
           });
       });

--- a/test/integration/json-api/v1/base-format/create/index.js
+++ b/test/integration/json-api/v1/base-format/create/index.js
@@ -170,20 +170,19 @@ describe('creatingResources', function() {
             var createData = res.body.data;
             expect(createData.id).to.be.a('string');
 
-            return Agent.request('GET', '/books/' + createData.id + '?include=stores')
+            return Agent.request('GET', '/books/' + createData.id + '?include=author,series,stores')
               .promise()
               .then(function(res) {
                 var readResult = res.body;
                 var payloadData = readResult.data;
                 var payloadLinks = payloadData.links;
 
-                expect(readResult.included.length).to.equal(1);
-                expect(readResult.included[0].id).to.equal(bookData.links.stores.id[0]);
+                expect(readResult.included.length).to.equal(3);
                 expect(payloadData.title).to.equal(bookData.title);
                 expect(payloadData.date_published).to.equal(bookData.date_published);
-                expect(payloadLinks.author.id).to.equal(bookData.links.author.id);
-                expect(payloadLinks.series.id).to.equal(bookData.links.series.id);
-                expect(payloadLinks.stores.id).to.deep.equal(bookData.links.stores.id);
+                expect(payloadLinks.author.linkage.id).to.equal(bookData.links.author.id);
+                expect(payloadLinks.series.linkage.id).to.equal(bookData.links.series.id);
+                expect(payloadLinks.stores.linkage[0].id).to.deep.equal(bookData.links.stores.id[0]);
               });
           });
       });

--- a/test/integration/json-api/v1/base-format/delete/index.js
+++ b/test/integration/json-api/v1/base-format/delete/index.js
@@ -36,7 +36,7 @@ describe('deletingResources', function() {
   });
 
   // TODO: Source/DB test: verify rollback on error
-  it.skip('must not allow partial updates');
+  it('must not allow partial updates');
 
   it('should delete resources when a DELETE request is made to the resource URL', function() {
     var first, second, deleteId;
@@ -81,11 +81,10 @@ describe('deletingResources', function() {
 
     // Not testable as written. Each error handling branch should be
     // unit-tested for proper HTTP semantics.
-
-    describe.skip('otherResponses', function() {
-      it('should use other HTTP codes to represent errors');
-      it('must interpret errors in accordance with HTTP semantics');
-      it('should return error details');
-    });
+    // describe('otherResponses', function() {
+    //   it('should use other HTTP codes to represent errors');
+    //   it('must interpret errors in accordance with HTTP semantics');
+    //   it('should return error details');
+    // });
   });
 });

--- a/test/integration/json-api/v1/base-format/errors/index.js
+++ b/test/integration/json-api/v1/base-format/errors/index.js
@@ -1,5 +1,5 @@
 // TODO: Implement
-describe.skip('errors', function() {
+describe('errors', function() {
   it('should return error objects that include additional information about problems encountered');
   it('should not return errors with primary data');
   it('should have an id member');

--- a/test/integration/json-api/v1/base-format/read/index.js
+++ b/test/integration/json-api/v1/base-format/read/index.js
@@ -151,13 +151,13 @@ describe('read', function() {
         });
 
         // TODO: Fix self urls to be baseUrl aware
-        it.skip('must set the value of "self" to a URL that identifies the resource represented by this object', function() {
+        it('must set the value of "self" to a URL that identifies the resource represented by this object', function() {
           return Agent.request('GET', '/books/1')
             .promise()
             .then(function(res) {
               var dataObj = res.body.data;
               expect(res.status).to.equal(200);
-              expect(dataObj.links.self).to.equal(Agent.baseUrl + '/books/1');
+              expect(dataObj.links.self).to.equal('/books/1');
             });
         });
 
@@ -166,7 +166,7 @@ describe('read', function() {
         it('may include a "linkage" member whose value represents "resource linkage"');
 
         // TODO: API TEST
-        it.skip('must respond to a get request to any `self` url with the resource as primary data');
+        it('must respond to a get request to any `self` url with the resource as primary data');
       });
 
       describe('resourceRelationships', function() {
@@ -265,7 +265,7 @@ describe('read', function() {
         });
 
         // TODO: implement
-        describe.skip('stringURLRelationship', function() {
+        describe('stringURLRelationship', function() {
           it('should not change related URL even when the resource changes');
         });
 
@@ -381,11 +381,11 @@ describe('read', function() {
     });
 
     // TODO: Meta object not currently used by endpoints
-    describe.skip('metaInformation', function() {
+    describe('metaInformation', function() {
       it('must be an object value');
     });
 
-    describe.skip('topLevelLinks', function() {
+    describe('topLevelLinks', function() {
       it('should not include members other than self, resource, and pagination links if necessary');
     });
   });
@@ -449,11 +449,11 @@ describe('read', function() {
     });
 
     describe('sparseFieldsets', function() {
-      it.skip('should support returning **only** specific fields in the response on a per-type basis by including a fields[TYPE] parameter', function() {
-        return Agent.request('GET', '/books/?fields=id,title')
+      it('should support returning **only** specific fields in the response on a per-type basis by including a fields[TYPE] parameter', function() {
+        return Agent.request('GET', '/books/?fields[books]=id,title')
           .promise()
           .then(function(res) {
-            var dataObj = res.body[0];
+            var dataObj = res.body.data[0];
             expect(dataObj).to.have.property('id');
             expect(dataObj).to.have.property('title');
             expect(dataObj).to.not.have.property('date_published');
@@ -470,6 +470,8 @@ describe('read', function() {
           });
       });
 
+      // TODO: Support sorting by nested relations
+      // https://github.com/endpoints/endpoints/issues/63
       it.skip('should support sorting by nested relationship attributes', function() {
         return Agent.request('GET', '/books/?sort=+author.name')
           .promise()
@@ -496,7 +498,7 @@ describe('read', function() {
     });
 
     // TODO: Pagination
-    describe.skip('pagination', function() {
+    describe('pagination', function() {
       it('should limit the number of resources returned in a response to a subset of the whole set available');
       it('should provide links to traverse a paginated data set');
       it('must put any pagination links on the object that corresponds to a collection');

--- a/test/integration/json-api/v1/base-format/read/index.js
+++ b/test/integration/json-api/v1/base-format/read/index.js
@@ -166,7 +166,7 @@ describe('read', function() {
         it('may include a "linkage" member whose value represents "resource linkage"');
 
         // TODO: API TEST
-        it('must respond to a get request to any `self` url with the resource as primary data');
+        // it('must respond to a get request to any `self` url with the resource as primary data');
       });
 
       describe('resourceRelationships', function() {

--- a/test/integration/json-api/v1/base-format/update/index.js
+++ b/test/integration/json-api/v1/base-format/update/index.js
@@ -101,10 +101,10 @@ describe('updatingResources', function() {
         type: 'books',
         title: 'tiddlywinks',
         links: {
-          stores: [
+          stores: {linkage: [
             {type: 'stores', id: '1'},
             {type: 'stores', id: '2'}
-          ]
+          ]}
         }
       };
       var firstRead;
@@ -130,8 +130,8 @@ describe('updatingResources', function() {
           expect(secondRead.included.length).to.equal(2);
           expect(payloadData.title).to.equal(patchData.data.title);
           expect(payloadData.date_published).to.equal(patchData.data.date_published);
-          expect(payloadLinks.stores.linkage[0].id).to.equal(updateLinks.stores[0].id);
-          expect(payloadLinks.stores.linkage[1].id).to.equal(updateLinks.stores[1].id);
+          expect(payloadLinks.stores.linkage[0].id).to.equal(updateLinks.stores.linkage[0].id);
+          expect(payloadLinks.stores.linkage[1].id).to.equal(updateLinks.stores.linkage[1].id);
 
         });
     });
@@ -162,11 +162,11 @@ describe('updatingResources', function() {
     });
   });
 
-  describe('updatingResourceToOneRelationships', function() {
-    it('must update to-One relationship with an object with type and id under links', function() {
+  describe('updatingResourceRelationships', function() {
+    it('must update to-One relationship with link object with linkage member', function() {
       patchData.data.links = {
-        author: {type: 'authors', id: '2'},
-        series: {type: 'series', id: '2'}
+        author: {linkage: {type: 'authors', id: '2'}},
+        series: {linkage: {type: 'series', id: '2'}}
       };
       return Agent.request('PATCH', '/books/1')
         .send(patchData)
@@ -179,13 +179,13 @@ describe('updatingResources', function() {
         .then(function(res) {
           var payloadLinks = res.body.data.links;
           var updateLinks = patchData.data.links;
-          expect(payloadLinks.author.linkage.id).to.equal(updateLinks.author.id);
-          expect(payloadLinks.series.linkage.id).to.equal(updateLinks.series.id);
+          expect(payloadLinks.author.linkage.id).to.equal(updateLinks.author.linkage.id);
+          expect(payloadLinks.series.linkage.id).to.equal(updateLinks.series.linkage.id);
         });
     });
 
     it('must attempt to remove to-One relationship with null', function() {
-      patchData.data.links = { series: null };
+      patchData.data.links = { series: {linkage: null }};
       return Agent.request('PATCH', '/books/1')
         .send(patchData)
         .promise()
@@ -206,10 +206,10 @@ describe('updatingResources', function() {
   describe('updatingResourceToManyRelationships', function() {
     it('must update homogeneous to-Many relationship with an object with type and id members under links', function() {
       patchData.data.links = {
-        stores: [
+        stores: { linkage: [
           { type: 'stores', id: '1' },
           { type: 'stores', id: '2' }
-        ]
+        ]}
       };
 
       return Agent.request('PATCH', '/books/1')
@@ -224,15 +224,15 @@ describe('updatingResources', function() {
           var payloadLinks = res.body.data.links;
           var updateLinks = patchData.data.links;
           expect(res.body.included.length).to.equal(2);
-          expect(payloadLinks.stores.linkage[0].id).to.equal(updateLinks.stores[0].id);
-          expect(payloadLinks.stores.linkage[1].id).to.equal(updateLinks.stores[1].id);
+          expect(payloadLinks.stores.linkage[0].id).to.equal(updateLinks.stores.linkage[0].id);
+          expect(payloadLinks.stores.linkage[1].id).to.equal(updateLinks.stores.linkage[1].id);
         });
     });
 
     // FIXME: https://gist.github.com/bobholt/1a5e9103be5fa85a53da#file-rc2-rc3-diff-L1753-L1760
     it('must attempt to remove to-Many relationships with the id member of the data object set to []', function() {
       patchData.data.links = {
-        stores: [],
+        stores: {linkage: []},
       };
 
       return Agent.request('PATCH', '/books/1')
@@ -300,7 +300,7 @@ describe('updatingResources', function() {
 
       it('must return 404 Not Found when processing a request that references a to-One related resource that does not exist', function() {
         patchData.data.links = {
-          author: {type: 'authors', id: '9999'},
+          author: {linkage: {type: 'authors', id: '9999'}}
         };
         return Agent.request('PATCH', '/books/1')
           .send(patchData)
@@ -312,7 +312,7 @@ describe('updatingResources', function() {
 
       it('must return 404 Not Found when processing a request that references a to-Many related resource that does not exist', function() {
         patchData.data.links = {
-          stores: [{type: 'stores', id: '9999'}]
+          stores: {linkage: [{type: 'stores', id: '9999'}]}
         };
         return Agent.request('PATCH', '/books/1')
           .send(patchData)
@@ -326,7 +326,7 @@ describe('updatingResources', function() {
     describe('409Conflict', function() {
       it('should return 409 Conflict when processing an update that violates server-enforced constraints', function() {
         patchData.data.links = {
-          author: null
+          author: {linkage: null}
         };
         return Agent.request('PATCH', '/books/1')
           .send(patchData)

--- a/test/integration/json-api/v1/base-format/update/index.js
+++ b/test/integration/json-api/v1/base-format/update/index.js
@@ -81,7 +81,7 @@ describe('updatingResources', function() {
   });
 
   // TODO: Source/DB test: verify rollback on error
-  it.skip('must not allow partial updates');
+  it('must not allow partial updates');
 
   describe('updatingResourceAttributes', function() {
     it('should allow only some attributes to be included in the resource object', function() {
@@ -403,12 +403,14 @@ describe('updatingRelationships', function() {
   });
 
   // TODO: Both of these tests seem to be broken for some reason now...
-  describe.skip('updatingToManyRelationships', function() {
+  describe('updatingToManyRelationships', function() {
     // /books/1/stores
     it('must update relationships with a PATCH request to a to-many relationship URL containing a data object with type and id members  and return 204 No Content on success', function() {
-      var newIds = ['1', '2'];
       return Agent.request('PATCH', '/books/1/links/stores')
-        .send({ data: { type: 'stores', id: newIds }})
+        .send({ data: [
+          { type: 'stores', id: '1' },
+          { type: 'stores', id: '2' }
+        ]})
         .promise()
         .then(function(res) {
           expect(res.status).to.equal(204);
@@ -417,14 +419,15 @@ describe('updatingRelationships', function() {
         .then(function(res) {
           var payloadLinks = res.body.data.links;
           expect(res.body).to.have.property('included');
-          expect(payloadLinks.stores.id).to.deep.equal(newIds);
+          expect(payloadLinks.stores.linkage[0].id).to.equal('1');
+          expect(payloadLinks.stores.linkage[1].id).to.equal('2');
         });
     });
 
     it('must remove relationships with a PATCH request to a to-many relationship URL containing a data object with a null value and return 204 No Content on success', function() {
       var newIds = [];
       return Agent.request('PATCH', '/books/1/links/stores')
-        .send({ data: { type: 'stores', id: newIds }})
+        .send({ data: []})
         .promise()
         .then(function(res) {
           expect(res.status).to.equal(204);
@@ -433,7 +436,7 @@ describe('updatingRelationships', function() {
         .then(function(res) {
           var payloadLinks = res.body.data.links;
           expect(res.body).to.not.have.property('included');
-          expect(payloadLinks.stores.id).to.deep.equal(newIds);
+          expect(payloadLinks.stores.linkage).to.deep.equal(newIds);
         });
     });
     it('must respond to POST requests to a to-many relationship URL');

--- a/test/integration/json-api/v1/base-format/update/index.js
+++ b/test/integration/json-api/v1/base-format/update/index.js
@@ -101,7 +101,10 @@ describe('updatingResources', function() {
         type: 'books',
         title: 'tiddlywinks',
         links: {
-          stores: {type: 'stores', id: ['1', '2']}
+          stores: [
+            {type: 'stores', id: '1'},
+            {type: 'stores', id: '2'}
+          ]
         }
       };
       var firstRead;
@@ -127,8 +130,8 @@ describe('updatingResources', function() {
           expect(secondRead.included.length).to.equal(2);
           expect(payloadData.title).to.equal(patchData.data.title);
           expect(payloadData.date_published).to.equal(patchData.data.date_published);
-          expect(payloadLinks.stores.linkage[0].id).to.equal(updateLinks.stores.id[0]);
-          expect(payloadLinks.stores.linkage[1].id).to.equal(updateLinks.stores.id[1]);
+          expect(payloadLinks.stores.linkage[0].id).to.equal(updateLinks.stores[0].id);
+          expect(payloadLinks.stores.linkage[1].id).to.equal(updateLinks.stores[1].id);
 
         });
     });
@@ -221,8 +224,8 @@ describe('updatingResources', function() {
           var payloadLinks = res.body.data.links;
           var updateLinks = patchData.data.links;
           expect(res.body.included.length).to.equal(2);
-          expect(payloadLinks.stores.linkage[0].id).to.equal(updateLinks.stores.id[0]);
-          expect(payloadLinks.stores.linkage[1].id).to.equal(updateLinks.stores.id[1]);
+          expect(payloadLinks.stores.linkage[0].id).to.equal(updateLinks.stores[0].id);
+          expect(payloadLinks.stores.linkage[1].id).to.equal(updateLinks.stores[1].id);
         });
     });
 
@@ -309,7 +312,7 @@ describe('updatingResources', function() {
 
       it('must return 404 Not Found when processing a request that references a to-Many related resource that does not exist', function() {
         patchData.data.links = {
-          stores: {type: 'stores', id: ['9999']}
+          stores: [{type: 'stores', id: '9999'}]
         };
         return Agent.request('PATCH', '/books/1')
           .send(patchData)

--- a/test/integration/json-api/v1/extensions/index.js
+++ b/test/integration/json-api/v1/extensions/index.js
@@ -7,6 +7,7 @@ describe('extensions', function () {
 
   it('must return supported extensions in the supported-ext parameter of the Content-Type header of every response');
   it('must render supported extensions as a comma-separated list');
+  it('must surround extension names with quotation marks when the media type parameter contains more than one extension name.');
 
   // Clients MAY request a particular media type extension by
   // including its name in the ext media type parameter with the


### PR DESCRIPTION
This is the largest unaddressed change between RC2 and RC3.

- Include self and related links for all related resources
- Resource object includes linkage object instead of type and id members
- Only include linkages if refers to included item in compound document
- STILL NEEDS: updating to-Many relationships request should send array of discrete resource objects, each with 1 type and 1 id--not 1 type with array of ids