### PR TITLE
Fix broken links on tutorial index

### DIFF
--- a/website/app/views/tutorial/index.jade
+++ b/website/app/views/tutorial/index.jade
@@ -12,11 +12,11 @@ block content
         route that serves data from a sqlite3 database to the browser.
       ul
         li
-          a(href="/tutorial/step-0") Step 0: Hello, Express!
+          a(href="/tutorial/0") Step 0: Hello, Express!
         li
-          a(href="/tutorial/step-1") Step 1: Hello, Knex!
+          a(href="/tutorial/1") Step 1: Hello, Knex!
         li
-          a(href="/tutorial/step-2") Step 2: Hello, Bookshelf!
+          a(href="/tutorial/2") Step 2: Hello, Bookshelf!
         li
-          a(href="/tutorial/step-3") Step 3: Hello, Endpoints!
+          a(href="/tutorial/3") Step 3: Hello, Endpoints!
   


### PR DESCRIPTION
The original links lead to a blank page and hitting "Back" or "Next" lead to http://endpointsjs.com/tutorial/NaN