### PR TITLE
Fix docs

### DIFF
--- a/src/request-handler/index.js
+++ b/src/request-handler/index.js
@@ -26,7 +26,7 @@ class RequestHandler {
     The constructor.
 
     @constructs RequestHandler
-    @param {Endpoints.Store.*} store
+    @param {Endpoints.Store} store
   */
   constructor (config={}) {
     this.config = config;

--- a/website/app/views/index.html
+++ b/website/app/views/index.html
@@ -24,7 +24,7 @@
 {
   "data": {
     "name": "endpoints",
-    "version": "0.5.6",
+    "version": "0.7.1",
     "repo": {
       "type": "github",
       "url": <a href="https://github.com/endpoints/endpoints">"https://github.com/endpoints/endpoints"</a>
@@ -33,7 +33,7 @@
       { "about": <a href="/about/">"/about"</a> },
       { "guides": <a href="/guides">"/guides"</a> },
       { "tutorial": <a href="/tutorial">"/tutorial"</a> },
-      { "API docs": <a href="/api/endpoints/0.5.6/index.html">"/api/index.html"</a>}
+      { "API docs": <a href="/api/endpoints/0.7.1/index.html">"/api/index.html"</a>}
     ],
     "authors": [
       <a href="https://github.com/tkellen">"tyler kellen"</a>,

--- a/website/app/views/partials/nav-main.jade
+++ b/website/app/views/partials/nav-main.jade
@@ -12,4 +12,4 @@ nav.main
       li
         a(href="/tutorial") Tutorial
       li
-        a(href="/api/endpoints/0.5.6/index.html") API Docs
+        a(href="/api/endpoints/0.7.1/index.html") API Docs


### PR DESCRIPTION
- remove jsdoc breaking change, see https://github.com/endpoints/endpoints/commit/38bbe63f3f021c5e3d524a3778e499e962e56e46#diff-a2f133d2738f821c5e11ee8e656b48edL29
- update broken link to APIdocs with correct version #