### PR TITLE
Update link to bookshelfjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## What is it?
 A pluggable hypermedia API framework compatible with any node http server or data store.
 
-Endpoints comes with a built in formatter for the [JSON API](http://jsonapi.org) specification and a storage adapter for [Bookshelf](http://bookshelf.js).
+Endpoints comes with a built in formatter for the [JSON API](http://jsonapi.org) specification and a storage adapter for [Bookshelf](http://bookshelfjs.org/).
 
 *Check out the [example implementation](https://github.com/endpoints/example).*
 


### PR DESCRIPTION
Link to http://bookshelf.js was broken, it is now http://bookshelfjs.org