### PR TITLE
Allow model definitions to override default method handlers or add new ones

### DIFF
--- a/es5/application/index.js
+++ b/es5/application/index.js
@@ -24,7 +24,7 @@ var Application = (function () {
 
     this._resources = {};
     this._endpoints = [];
-    _lodash2['default'].extend(this, _libParse_options2['default'](opts));
+    _lodash2['default'].extend(this, (0, _libParse_options2['default'])(opts));
   }
 
   Application.prototype.resource = function resource(name) {
@@ -40,7 +40,7 @@ var Application = (function () {
       input.forEach(this.register.bind(this));
       return this;
     }
-    var resource = _libParse_resource2['default'](input, this.searchPaths);
+    var resource = (0, _libParse_resource2['default'])(input, this.searchPaths);
     var resourceName = resource.name;
     if (this._resources[resourceName]) {
       throw new Error('Resource "' + resourceName + '" registered twice');

--- a/es5/application/lib/parse_options.js
+++ b/es5/application/lib/parse_options.js
@@ -3,7 +3,7 @@
 exports.__esModule = true;
 
 exports['default'] = function () {
-  var opts = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+  var opts = arguments[0] === undefined ? {} : arguments[0];
 
   if (!opts.routeBuilder) {
     throw new Error('No route builder specified.');

--- a/es5/application/lib/parse_resource.js
+++ b/es5/application/lib/parse_resource.js
@@ -19,12 +19,12 @@ var _require_silent2 = _interopRequireDefault(_require_silent);
 exports['default'] = function (name, searchPaths) {
   var routeModulePath, moduleBasePath;
   if (typeof name === 'string') {
-    routeModulePath = _require_search2['default'](_path2['default'].join(name, 'routes'), searchPaths);
+    routeModulePath = (0, _require_search2['default'])(_path2['default'].join(name, 'routes'), searchPaths);
     moduleBasePath = _path2['default'].dirname(routeModulePath);
     return {
       name: name,
       routes: require(routeModulePath),
-      controller: _require_silent2['default'](_path2['default'].join(moduleBasePath, 'controller'))
+      controller: (0, _require_silent2['default'])(_path2['default'].join(moduleBasePath, 'controller'))
     };
   }
   if (!name) {

--- a/es5/application/lib/require_search.js
+++ b/es5/application/lib/require_search.js
@@ -21,7 +21,7 @@ exports['default'] = function (file, searchPaths) {
   for (var i = 0; i < len; i++) {
     var currentPath = _path2['default'].join(searchPaths[i], file);
     var notFoundInFoundFile = false;
-    result = _require_silent2['default'](currentPath);
+    result = (0, _require_silent2['default'])(currentPath);
     if (result instanceof Error) {
       // handle situations where a file is found, but requiring it
       // still throws a MODULE_NOT_FOUND error because that file

--- a/es5/controller/index.js
+++ b/es5/controller/index.js
@@ -32,23 +32,6 @@ var _libSingle_slash_join2 = _interopRequireDefault(_libSingle_slash_join);
 */
 
 var Controller = (function () {
-  Controller.extend = function extend() {
-    var props = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
-
-    return (function (_ref) {
-      function Controller() {
-        var opts = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
-
-        _classCallCheck(this, Controller);
-
-        _ref.call(this, _lodash2['default'].extend({}, props, opts));
-      }
-
-      _inherits(Controller, _ref);
-
-      return Controller;
-    })(this);
-  };
 
   /**
     The constructor.
@@ -63,7 +46,7 @@ var Controller = (function () {
   */
 
   function Controller() {
-    var config = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+    var config = arguments[0] === undefined ? {} : arguments[0];
 
     _classCallCheck(this, Controller);
 
@@ -89,6 +72,24 @@ var Controller = (function () {
     }, config);
   }
 
+  Controller.extend = function extend() {
+    var props = arguments[0] === undefined ? {} : arguments[0];
+
+    return (function (_ref) {
+      function Controller() {
+        var opts = arguments[0] === undefined ? {} : arguments[0];
+
+        _classCallCheck(this, Controller);
+
+        _ref.call(this, _lodash2['default'].extend({}, props, opts));
+      }
+
+      _inherits(Controller, _ref);
+
+      return Controller;
+    })(this);
+  };
+
   /**
     Used for generating CRUD methods.
      @param {String} method - The name of the function to be created.
@@ -105,12 +106,12 @@ var Controller = (function () {
       sort: [],
       schema: {}
     }, this.config, opts);
-    var validationFailures = _libValidate2['default'](_method, config);
+    var validationFailures = (0, _libValidate2['default'])(_method, config);
     if (validationFailures.length) {
       throw new Error(validationFailures.join('\n'));
     }
     // TODO: fix this gross passing of the url
-    return _libHandle2['default'](config, this.url);
+    return (0, _libHandle2['default'])(config, this.url);
   };
 
   Controller.prototype.create = function create(opts) {
@@ -151,7 +152,7 @@ var Controller = (function () {
 
   _createClass(Controller, [{
     key: 'capabilities',
-    get: function get() {
+    get: function () {
       var _config = this.config;
       var store = _config.store;
       var model = _config.model;
@@ -164,18 +165,18 @@ var Controller = (function () {
     }
   }, {
     key: 'baseUrl',
-    get: function get() {
+    get: function () {
       return this.config.baseUrl;
     }
   }, {
     key: 'basePath',
-    get: function get() {
+    get: function () {
       return this.config.basePath;
     }
   }, {
     key: 'url',
-    get: function get() {
-      return _libSingle_slash_join2['default']([this.baseUrl, this.basePath]);
+    get: function () {
+      return (0, _libSingle_slash_join2['default'])([this.baseUrl, this.basePath]);
     }
   }]);
 

--- a/es5/controller/lib/handle.js
+++ b/es5/controller/lib/handle.js
@@ -30,8 +30,9 @@ module.exports = function (config, baseUrl) {
 
   return function (request, response) {
     var server = 'express'; // detect if hapi or express here
-    var process = requestHandler[method].bind(requestHandler);
-    var format = payloadHandler[method].bind(payloadHandler, config);
+    var modelHandlers = config.model.methodHandlers;
+    var process = modelHandlers && modelHandlers[method] ? modelHandlers[method].request.bind(requestHandler) : requestHandler[method].bind(requestHandler);
+    var format = modelHandlers && modelHandlers[method] ? modelHandlers[method].payload.bind(payloadHandler, config) : payloadHandler[method].bind(payloadHandler, config);
     var respond = (responder ? responder : send[server]).bind(null, response);
     var errors = requestHandler.validate(request);
 

--- a/es5/controller/lib/single_slash_join.js
+++ b/es5/controller/lib/single_slash_join.js
@@ -3,7 +3,7 @@
 exports.__esModule = true;
 
 exports['default'] = function () {
-  var input = arguments.length <= 0 || arguments[0] === undefined ? [] : arguments[0];
+  var input = arguments[0] === undefined ? [] : arguments[0];
 
   if (!Array.isArray(input)) {
     throw new Error('Input must be an array.');

--- a/es5/controller/lib/validate.js
+++ b/es5/controller/lib/validate.js
@@ -14,5 +14,5 @@ module.exports = function (method, config) {
   var model = config.model;
   var store = config.store;
 
-  return _lodash2['default'].compose(_lodash2['default'].flatten, _lodash2['default'].compact)([_model_has2['default'](store.allRelations(model), config.include, 'relations'), _model_has2['default'](Object.keys(store.filters(model)), Object.keys(config.filter), 'filters')]);
+  return _lodash2['default'].compose(_lodash2['default'].flatten, _lodash2['default'].compact)([(0, _model_has2['default'])(store.allRelations(model), config.include, 'relations'), (0, _model_has2['default'])(Object.keys(store.filters(model)), Object.keys(config.filter), 'filters')]);
 };

--- a/es5/format-jsonapi/index.js
+++ b/es5/format-jsonapi/index.js
@@ -28,7 +28,7 @@ var JsonApiFormat = (function () {
    */
 
   function JsonApiFormat() {
-    var opts = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+    var opts = arguments[0] === undefined ? {} : arguments[0];
 
     _classCallCheck(this, JsonApiFormat);
 
@@ -47,7 +47,7 @@ var JsonApiFormat = (function () {
    */
 
   JsonApiFormat.prototype.selfUrl = function selfUrl(model) {
-    return this.baseUrl + '/' + this.store.id(model);
+    return '' + this.baseUrl + '/' + this.store.id(model);
   };
 
   /**
@@ -58,7 +58,7 @@ var JsonApiFormat = (function () {
    */
 
   JsonApiFormat.prototype.relatedUrl = function relatedUrl(model, relation) {
-    return this.baseUrl + '/' + this.store.id(model) + '/' + relation;
+    return '' + this.baseUrl + '/' + this.store.id(model) + '/' + relation;
   };
 
   /**
@@ -69,7 +69,7 @@ var JsonApiFormat = (function () {
    */
 
   JsonApiFormat.prototype.relationUrl = function relationUrl(model, relation) {
-    return this.baseUrl + '/' + this.store.id(model) + '/relationships/' + relation;
+    return '' + this.baseUrl + '/' + this.store.id(model) + '/relationships/' + relation;
   };
 
   /**
@@ -83,7 +83,7 @@ var JsonApiFormat = (function () {
   JsonApiFormat.prototype.process = function process(input) {
     var _this = this;
 
-    var opts = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+    var opts = arguments[1] === undefined ? {} : arguments[1];
     var singleResult = opts.singleResult;
     var relations = opts.relations;
     var mode = opts.mode;
@@ -124,8 +124,8 @@ var JsonApiFormat = (function () {
    */
 
   JsonApiFormat.prototype.format = function format(model) {
-    var includedRelations = arguments.length <= 1 || arguments[1] === undefined ? [] : arguments[1];
-    var mode = arguments.length <= 2 || arguments[2] === undefined ? 'read' : arguments[2];
+    var includedRelations = arguments[1] === undefined ? [] : arguments[1];
+    var mode = arguments[2] === undefined ? 'read' : arguments[2];
 
     var store = this.store;
     var id = store.id(model);
@@ -179,7 +179,7 @@ var JsonApiFormat = (function () {
       // remove duplicates.
       // FIXME: this can produce invalid documents when there is
       // a nesting level higher than three.
-      var indexKey = '' + doc.id + doc.type;
+      var indexKey = '' + doc.id + '' + doc.type;
       var skip = includedIndex.some(function (entry) {
         return entry == indexKey;
       });

--- a/es5/payload-handler/index.js
+++ b/es5/payload-handler/index.js
@@ -42,7 +42,7 @@ var PayloadHandler = (function () {
 
   PayloadHandler.prototype.read = function read(config, data) {
     if ((!data || data.length === 0 && data.singleResult) && data.mode !== 'related') {
-      return this.error(_kapow2['default'](404, 'Resource not found.'));
+      return this.error((0, _kapow2['default'])(404, 'Resource not found.'));
     }
 
     return {
@@ -104,7 +104,7 @@ var PayloadHandler = (function () {
     var resp;
 
     defaultErr = defaultErr || 400;
-    errs = errs || [_kapow2['default'](defaultErr)];
+    errs = errs || [(0, _kapow2['default'])(defaultErr)];
 
     if (!Array.isArray(errs)) {
       errs = [errs];

--- a/es5/request-handler/index.js
+++ b/es5/request-handler/index.js
@@ -59,7 +59,7 @@ var RequestHandler = (function () {
   */
 
   function RequestHandler() {
-    var config = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+    var config = arguments[0] === undefined ? {} : arguments[0];
 
     _classCallCheck(this, RequestHandler);
 
@@ -123,9 +123,9 @@ var RequestHandler = (function () {
     var sort = _request$query.sort;
 
     return {
-      include: include ? _libCollapse_include2['default'](include.split(',')) : config.include,
-      filter: filter ? _libSplit_string_props2['default'](filter) : config.filter,
-      fields: fields ? _libSplit_string_props2['default'](fields) : config.fields,
+      include: include ? (0, _libCollapse_include2['default'])(include.split(',')) : config.include,
+      filter: filter ? (0, _libSplit_string_props2['default'])(filter) : config.filter,
+      fields: fields ? (0, _libSplit_string_props2['default'])(fields) : config.fields,
       sort: sort ? sort.split(',') : config.sort
     };
   };
@@ -239,12 +239,12 @@ var RequestHandler = (function () {
 
   _createClass(RequestHandler, [{
     key: 'store',
-    get: function get() {
+    get: function () {
       return this.config.store;
     }
   }, {
     key: 'model',
-    get: function get() {
+    get: function () {
       return this.config.model;
     }
   }]);

--- a/es5/request-handler/lib/throw_if_model.js
+++ b/es5/request-handler/lib/throw_if_model.js
@@ -10,7 +10,7 @@ var _kapow2 = _interopRequireDefault(_kapow);
 
 exports['default'] = function (model) {
   if (model) {
-    throw _kapow2['default'](409, 'Model with this ID already exists');
+    throw (0, _kapow2['default'])(409, 'Model with this ID already exists');
   }
   return model;
 };

--- a/es5/request-handler/lib/throw_if_no_model.js
+++ b/es5/request-handler/lib/throw_if_no_model.js
@@ -10,7 +10,7 @@ var _kapow2 = _interopRequireDefault(_kapow);
 
 exports['default'] = function (model) {
   if (!model) {
-    throw _kapow2['default'](404, 'Unable to locate model.');
+    throw (0, _kapow2['default'])(404, 'Unable to locate model.');
   }
 
   // Bookshelf throws an error for any number of unrelated reasons.

--- a/es5/request-handler/lib/verify_client_generated_id.js
+++ b/es5/request-handler/lib/verify_client_generated_id.js
@@ -22,7 +22,7 @@ exports['default'] = function (request) {
     err = !!data.id;
   }
 
-  return err ? _kapow2['default'](403, 'Client generated IDs are not enabled.') : null;
+  return err ? (0, _kapow2['default'])(403, 'Client generated IDs are not enabled.') : null;
 };
 
 module.exports = exports['default'];

--- a/es5/request-handler/lib/verify_content_type.js
+++ b/es5/request-handler/lib/verify_content_type.js
@@ -18,7 +18,7 @@ exports['default'] = function (request) {
   var isValidContentType = contentType && contentType.toLowerCase().indexOf(EXPECTED_TYPE) === 0;
 
   if (!isValidContentType) {
-    err = _kapow2['default'](415, 'Content-Type must be "' + EXPECTED_TYPE + '"');
+    err = (0, _kapow2['default'])(415, 'Content-Type must be "' + EXPECTED_TYPE + '"');
   }
 
   return err;

--- a/es5/request-handler/lib/verify_data_object.js
+++ b/es5/request-handler/lib/verify_data_object.js
@@ -21,7 +21,7 @@ exports['default'] = function (request, endpoint) {
 
   if (method === 'create') {
     if (!_lodash2['default'].isPlainObject(data)) {
-      err = _kapow2['default'](400, 'Primary data must be a single object or array.');
+      err = (0, _kapow2['default'])(400, 'Primary data must be a single object or array.');
       return err;
     }
   }
@@ -40,7 +40,7 @@ exports['default'] = function (request, endpoint) {
   id = request.params && request.params.id;
 
   if (!isValidType) {
-    err = _kapow2['default'](400, 'Primary data must include a type.');
+    err = (0, _kapow2['default'])(400, 'Primary data must include a type.');
     return err;
   }
 

--- a/es5/request-handler/lib/verify_full_replacement.js
+++ b/es5/request-handler/lib/verify_full_replacement.js
@@ -38,7 +38,7 @@ exports['default'] = function (request, endpoint) {
     err = hasToManyLinkage(data);
   }
 
-  return err ? _kapow2['default'](403, 'Full replacement of to-Many relations is not allowed.') : null;
+  return err ? (0, _kapow2['default'])(403, 'Full replacement of to-Many relations is not allowed.') : null;
 };
 
 module.exports = exports['default'];

--- a/es5/store-bookshelf/lib/_read_for_related.js
+++ b/es5/store-bookshelf/lib/_read_for_related.js
@@ -86,12 +86,12 @@ var _read2 = _interopRequireDefault(_read);
 */
 
 function readForRelated(mode, sourceModel, id, relation, query) {
-  return _by_id2['default'](sourceModel, id, relation).then(function (result) {
+  return (0, _by_id2['default'])(sourceModel, id, relation).then(function (result) {
     if (!result) {
-      throw _kapow2['default'](404);
+      throw (0, _kapow2['default'])(404);
     }
-    var relatedData = _related2['default'](result, relation);
-    var hasMany = _is_many2['default'](relatedData);
+    var relatedData = (0, _related2['default'])(result, relation);
+    var hasMany = (0, _is_many2['default'])(relatedData);
 
     var relatedModel = hasMany ? relatedData.model : relatedData.constructor;
     var relatedIds = hasMany ? relatedData.map(function (m) {
@@ -109,7 +109,7 @@ function readForRelated(mode, sourceModel, id, relation, query) {
 
     query.singleResult = !hasMany;
 
-    return _read2['default'](relatedModel, query, mode).then(function (relatedResult) {
+    return (0, _read2['default'])(relatedModel, query, mode).then(function (relatedResult) {
       relatedResult.sourceModel = result;
       relatedResult.relationName = relation;
       return relatedResult;

--- a/es5/store-bookshelf/lib/by_id.js
+++ b/es5/store-bookshelf/lib/by_id.js
@@ -17,7 +17,7 @@ function byId(model, id, relations) {
   })['catch'](TypeError, function (e) {
     // A TypeError here most likely signifies bad
     // relations passed into withRelated
-    throw _kapow2['default'](404, 'Unable to find relations');
+    throw (0, _kapow2['default'])(404, 'Unable to find relations');
   });
 }
 

--- a/es5/store-bookshelf/lib/create.js
+++ b/es5/store-bookshelf/lib/create.js
@@ -26,21 +26,21 @@ var _relate2 = _interopRequireDefault(_relate);
  */
 
 function create(model) {
-  var params = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+  var params = arguments[1] === undefined ? {} : arguments[1];
 
   if (!model) {
     throw new Error('No model provided.');
   }
-  return _destructure2['default'](model.forge(), params).then(function (destructured) {
+  return (0, _destructure2['default'])(model.forge(), params).then(function (destructured) {
     var attributes = destructured.attributes;
     var relations = destructured.relations;
 
-    return _transact2['default'](model, function (transaction) {
+    return (0, _transact2['default'])(model, function (transaction) {
       return model.forge(attributes).save(null, {
         method: 'insert',
         transacting: transaction
       }).tap(function (newModel) {
-        return _relate2['default'](newModel, relations, 'create', transaction);
+        return (0, _relate2['default'])(newModel, relations, 'create', transaction);
       }).then(function (newModel) {
         return model.forge({ id: newModel.id }).fetch({ transacting: transaction });
       });

--- a/es5/store-bookshelf/lib/create_relation.js
+++ b/es5/store-bookshelf/lib/create_relation.js
@@ -42,17 +42,17 @@ function createRelation(model, relationName, data) {
   if (!model) {
     throw new Error('No model provided.');
   }
-  return _transact2['default'](model, function (transaction) {
-    var existing = _related2['default'](model, relationName).map(function (rel) {
+  return (0, _transact2['default'])(model, function (transaction) {
+    var existing = (0, _related2['default'])(model, relationName).map(function (rel) {
       return {
-        id: _id2['default'](rel),
-        type: _type2['default'](rel)
+        id: (0, _id2['default'])(rel),
+        type: (0, _type2['default'])(rel)
       };
     });
     var all = data.concat(existing);
     // TODO: should i be doing a deep comparison instead?
     var unique = _lodash2['default'].uniq(all, JSON.stringify.bind(null));
-    return _relate2['default'](model, {
+    return (0, _relate2['default'])(model, {
       name: relationName,
       data: unique
     }, 'add', transaction);

--- a/es5/store-bookshelf/lib/destroy_relation.js
+++ b/es5/store-bookshelf/lib/destroy_relation.js
@@ -29,10 +29,10 @@ function destroyRelation(model, relations) {
   if (!model) {
     throw new Error('No model provided.');
   }
-  return _destructure2['default'](model, relations).then(function (destructured) {
+  return (0, _destructure2['default'])(model, relations).then(function (destructured) {
     var relations = destructured.relations;
-    return _transact2['default'](model, function (transaction) {
-      return _relate2['default'](model, relations, 'delete', transaction);
+    return (0, _transact2['default'])(model, function (transaction) {
+      return (0, _relate2['default'])(model, relations, 'delete', transaction);
     });
   });
 }

--- a/es5/store-bookshelf/lib/destructure.js
+++ b/es5/store-bookshelf/lib/destructure.js
@@ -25,12 +25,12 @@ var _all_relations = require('./all_relations');
 var _all_relations2 = _interopRequireDefault(_all_relations);
 
 function destructure(model) {
-  var params = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+  var params = arguments[1] === undefined ? {} : arguments[1];
 
   var relationships = params.relationships || {};
   var relationshipNames = _lodash2['default'].keys(relationships);
-  var allRels = _all_relations2['default'](model);
-  var toOneRelsMap = _to_one_relations2['default'](model);
+  var allRels = (0, _all_relations2['default'])(model);
+  var toOneRelsMap = (0, _to_one_relations2['default'])(model);
   var toOneRels = Object.keys(toOneRelsMap);
   var toManyRels = _lodash2['default'].difference(allRels, toOneRels);
   var linkedToOneRels = _lodash2['default'].intersection(relationshipNames, toOneRels);
@@ -60,7 +60,7 @@ function destructure(model) {
     };
   });
 
-  return _columns2['default'](model).then(function (modelColumns) {
+  return (0, _columns2['default'])(model).then(function (modelColumns) {
     if (_lodash2['default'].contains(modelColumns, 'id') && params.id) {
       attributes.id = params.id;
     }

--- a/es5/store-bookshelf/lib/read.js
+++ b/es5/store-bookshelf/lib/read.js
@@ -31,12 +31,12 @@ var _columns2 = _interopRequireDefault(_columns);
 */
 
 function read(model) {
-  var query = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-  var mode = arguments.length <= 2 || arguments[2] === undefined ? 'read' : arguments[2];
+  var query = arguments[1] === undefined ? {} : arguments[1];
+  var mode = arguments[2] === undefined ? 'read' : arguments[2];
 
-  return _columns2['default'](model).then(function (modelColumns) {
-    var fields = query.fields && query.fields[_type2['default'](model)];
-    var relations = _lodash2['default'].intersection(_all_relations2['default'](model), query.include || []);
+  return (0, _columns2['default'])(model).then(function (modelColumns) {
+    var fields = query.fields && query.fields[(0, _type2['default'])(model)];
+    var relations = _lodash2['default'].intersection((0, _all_relations2['default'])(model), query.include || []);
     if (fields) {
       fields = _lodash2['default'].intersection(modelColumns, fields);
       // ensure we always select id as the spec requires this to be present

--- a/es5/store-bookshelf/lib/related.js
+++ b/es5/store-bookshelf/lib/related.js
@@ -25,12 +25,12 @@ var _is_many2 = _interopRequireDefault(_is_many);
 
 function related(input, relation) {
   return relation.split('.').reduce(function (input, relationSegment) {
-    if (_is_many2['default'](input)) {
+    if ((0, _is_many2['default'])(input)) {
       // iterate each model and add its related models to the collection
       return input.reduce(function (result, model) {
         var related = model.related(relationSegment);
         return result.add(related.models ? related.models : related);
-      }, _related_collection2['default'](input.model, relationSegment));
+      }, (0, _related_collection2['default'])(input.model, relationSegment));
     }
     return input.related(relationSegment);
   }, input);

--- a/es5/store-bookshelf/lib/to_one_relations.js
+++ b/es5/store-bookshelf/lib/to_one_relations.js
@@ -20,7 +20,7 @@ var _all_relations2 = _interopRequireDefault(_all_relations);
  */
 
 function toOneRelations(model) {
-  return _all_relations2['default'](model).reduce(function (result, relation) {
+  return (0, _all_relations2['default'])(model).reduce(function (result, relation) {
     // nested relations are specified by dot notated strings
     // if a relation has a dot in it, it is nested, and therefor
     // cannot be a toOne relation. ignore it.

--- a/es5/store-bookshelf/lib/update.js
+++ b/es5/store-bookshelf/lib/update.js
@@ -31,7 +31,7 @@ var _relate2 = _interopRequireDefault(_relate);
  */
 
 function update(model) {
-  var params = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+  var params = arguments[1] === undefined ? {} : arguments[1];
 
   if (!model) {
     throw new Error('No model provided.');
@@ -39,17 +39,17 @@ function update(model) {
   var currentState = model.toJSON({ shallow: true });
   currentState.id = String(currentState.id);
 
-  return _destructure2['default'](model, params).then(function (destructured) {
+  return (0, _destructure2['default'])(model, params).then(function (destructured) {
     var attributes = destructured.attributes;
     var relations = destructured.relations;
 
-    return _transact2['default'](model, function (transaction) {
+    return (0, _transact2['default'])(model, function (transaction) {
       return model.save(attributes, {
         patch: true,
         method: 'update',
         transacting: transaction
       }).tap(function (model) {
-        return _relate2['default'](model, relations, 'update', transaction);
+        return (0, _relate2['default'])(model, relations, 'update', transaction);
       }).then(function (model) {
         // if model didn't change, return null
         // model.previousAttributes() is broken.

--- a/es5/validate-json-schema/index.js
+++ b/es5/validate-json-schema/index.js
@@ -15,7 +15,7 @@ var _isMyJsonValid2 = _interopRequireDefault(_isMyJsonValid);
 function transformErrorFields(input, errors) {
   return errors.map(function (error) {
     var field = error.field.replace(/^data/, input);
-    return _kapow2['default'](400, field + ' ' + error.message, error);
+    return (0, _kapow2['default'])(400, field + ' ' + error.message, error);
   });
 }
 
@@ -24,7 +24,7 @@ exports['default'] = function (request, endpoint) {
   var schema = endpoint.schema || {};
 
   for (var prop in schema) {
-    var validate = _isMyJsonValid2['default'](schema[prop] || {});
+    var validate = (0, _isMyJsonValid2['default'])(schema[prop] || {});
     if (!validate(request[prop])) {
       err = transformErrorFields(prop, validate.errors);
       break;

--- a/src/controller/lib/handle.js
+++ b/src/controller/lib/handle.js
@@ -14,8 +14,13 @@ module.exports = function (config, baseUrl) {
 
   return function (request, response) {
     const server = 'express'; // detect if hapi or express here
-    const process = requestHandler[method].bind(requestHandler);
-    const format = payloadHandler[method].bind(payloadHandler, config);
+    const modelHandlers = config.model.methodHandlers;
+    const process = modelHandlers && modelHandlers[method] ?
+      modelHandlers[method].request.bind(requestHandler) :
+      requestHandler[method].bind(requestHandler);
+    const format = modelHandlers && modelHandlers[method] ?
+      modelHandlers[method].payload.bind(payloadHandler, config) :
+      payloadHandler[method].bind(payloadHandler, config);
     const respond = (responder ? responder : send[server]).bind(null, response);
     const errors = requestHandler.validate(request);
 


### PR DESCRIPTION
- Required by [Away](https://github.com/bocoup/api/blob/master/src/modules/core/leave-requests/model.js#L38-L46)
  - (definition to be changed to `methodHandlers:{creatWithActivity:{request:function(){},payload:function(){}}})`