### PR TITLE
allow default includes on create

### DIFF
--- a/src/format-jsonapi/index.js
+++ b/src/format-jsonapi/index.js
@@ -66,23 +66,23 @@ class JsonApiFormat {
    * @param {opts} opts - configurable options (@todo: cleanup)
    */
   process (input, opts={}) {
-    const {singleResult, relations, mode} = opts;
+    const {singleResult, include, mode} = opts;
     let links;
     if (mode === 'relation') {
       links = this._relationshipLinks(input.sourceModel, input.relationName);
     }
     let data;
     if (this.store.isMany(input)) {
-      data = input.map((input) => this.format(input, relations, mode));
+      data = input.map((input) => this.format(input, include, mode));
     } else {
-      data = this.format(input, relations, mode);
+      data = this.format(input, include, mode);
     }
     if (singleResult && Array.isArray(data)) {
       data = data.length ? data[0] : null;
     }
     let included;
-    if (relations && relations.length) {
-      included = this.include(input, relations);
+    if (include && include.length) {
+      included = this.include(input, include);
     }
     return {
       data,

--- a/src/payload-handler/index.js
+++ b/src/payload-handler/index.js
@@ -8,12 +8,10 @@ class PayloadHandler {
   }
 
   create (config, data) {
+    config.singleResult = true;
     return {
       code: '201',
-      data: this.formatter.process(data, {
-        singleResult: true,
-        relations: config.include
-      }),
+      data: this.formatter.process(data, config),
       headers: {
         location: this.formatter.selfUrl(data)
       }
@@ -36,7 +34,7 @@ class PayloadHandler {
       code: '200',
       data: this.formatter.process(data, {
         singleResult: data.singleResult,
-        relations: data.relations,
+        include: data.relations,
         mode: data.mode,
         baseType: data.baseType,
         baseId: data.baseId,

--- a/src/payload-handler/index.js
+++ b/src/payload-handler/index.js
@@ -11,7 +11,8 @@ class PayloadHandler {
     return {
       code: '201',
       data: this.formatter.process(data, {
-        singleResult: true
+        singleResult: true,
+        relations: config.include
       }),
       headers: {
         location: this.formatter.selfUrl(data)

--- a/src/request-handler/index.js
+++ b/src/request-handler/index.js
@@ -108,15 +108,16 @@ class RequestHandler {
   create (request) {
     const {store, model} = this;
     const data = request.body.data;
+    const query = this.query(request);
     if (data && data.id) {
       return store.byId(model, data.id)
         .then(throwIfModel)
         .then(function() {
-          return store.create(model, data);
+          return store.create(model, data, query);
         }
       );
     } else {
-      return store.create(model, data);
+      return store.create(model, data, query);
     }
   }
 
@@ -162,10 +163,11 @@ class RequestHandler {
 
   update (request) {
     const store = this.store;
+    const query = this.query(request);
     return store.byId(this.model, request.params.id).
       then(throwIfNoModel).
       then((model) => {
-        return store.update(model, request.body.data);
+        return store.update(model, request.body.data, query);
       });
   }
 

--- a/src/store-bookshelf/lib/create.js
+++ b/src/store-bookshelf/lib/create.js
@@ -1,15 +1,17 @@
 import transact from './_transact';
 import destructure from './destructure';
 import relate from './relate';
+import read from './read';
 
 /**
  * Creates a model.
  *
  * @param {Bookshelf.Model} model - A bookshelf model instance
  * @param {Object} params - An object containing the params from the request.
+ * @param {Object} config - The config for the controller calling this.
  * @returns {Promise.Bookshelf.Model} The created model.
  */
-export default function create (model, params={}) {
+export default function create (model, params={}, config={}) {
   if (!model) {
     throw new Error('No model provided.');
   }
@@ -23,8 +25,11 @@ export default function create (model, params={}) {
       .tap((newModel) => {
         return relate(newModel, relations, 'create', transaction);
       })
+      .tap(transaction.commit)
       .then((newModel) => {
-        return model.forge({id:newModel.id}).fetch({transacting: transaction});
+        config.filter.id = newModel.id;
+        config.singleResult = true;
+        return read(model, config);
       });
     });
   });

--- a/src/store-bookshelf/lib/update.js
+++ b/src/store-bookshelf/lib/update.js
@@ -8,10 +8,11 @@ import relate from './relate';
  *
  * @param {Bookshelf.Model} model - A bookshelf model instance
  * @param {Object} params - An object containing the params from the request.
+ * @param {Object} config - The config for the controller calling this.
  * @returns {Promise.Bookshelf.Model|null} -
      The updated model or null if nothing has changed.
  */
-export default function update (model, params={}) {
+export default function update (model, params={}, config={}) {
   if (!model) {
     throw new Error('No model provided.');
   }


### PR DESCRIPTION
This allows `controller.create({include:['relation']})` to format the response for created record with embedded includes. This should also be supported for PATCH. This shouldn't be merged until tests have been added.