### PR TITLE
Fix schema validation

### DIFF
--- a/src/validate-json-schema/index.js
+++ b/src/validate-json-schema/index.js
@@ -10,7 +10,7 @@ function transformErrorFields(input, errors) {
 
 export default function (request, endpoint) {
   var err;
-  var schema = endpoint.schema || {};
+  var schema = endpoint.config.schema || {};
 
   for (var prop in schema) {
     var validate = validator(schema[prop] || {});

--- a/test/app/src/modules/authors/schema.js
+++ b/test/app/src/modules/authors/schema.js
@@ -1,19 +1,41 @@
 module.exports = {
   body: {
+    required: true,
+    type: 'object',
     properties: {
-      id: {
-        type: 'integer'
+      data: {
+        required: true,
+        type: 'object',
+        properties: {
+          type: {
+            required: true,
+            type: 'string'
+          },
+          attributes: {
+            required: true,
+            type: 'object',
+            properties: {
+              id: {
+                type: 'integer'
+              },
+              name: {
+                type: 'string'
+              },
+              date_of_birth: {
+                type: 'string',
+                format: 'date-time'
+              },
+              date_of_death: {
+                type: 'string',
+                format: 'date-time'
+              }
+            }
+          }
+        }
       },
-      name: {
-        type: 'string'
-      },
-      date_of_birth: {
-        type: 'string',
-        format: 'date-time'
-      },
-      date_of_death: {
-        type: 'string',
-        format: 'date-time'
+      relationships: {
+        required: false,
+        type: 'object',
       }
     }
   }

--- a/test/app/src/modules/books/schema.js
+++ b/test/app/src/modules/books/schema.js
@@ -1,20 +1,43 @@
 module.exports = {
   body: {
+    required: true,
+    type: 'object',
     properties: {
-      id: {
-        type: 'integer'
-      },
-      title: {
-        type: 'string'
-      },
-      ordering: {
-        type: 'string',
-        format: 'date-time'
-      },
-      links: {
-        author: {
-          type: 'string'
+      data: {
+        required: true,
+        type: 'object',
+        properties: {
+          type: {
+            required: true,
+            type: 'string'
+          },
+          attributes: {
+            required: true,
+            type: 'object',
+            properties: {
+              id: {
+                required: false,
+                type: 'integer'
+              },
+              title: {
+                type: 'string'
+              },
+              ordering: {
+                type: 'string',
+                format: 'date-time'
+              },
+              links: {
+                author: {
+                  type: 'string'
+                }
+              }
+            }
+          }
         }
+      },
+      relationships: {
+        required: false,
+        type: 'object',
       }
     }
   }

--- a/test/app/src/modules/chapters/schema.js
+++ b/test/app/src/modules/chapters/schema.js
@@ -1,20 +1,42 @@
 module.exports = {
   body: {
+    required: true,
+    type: 'object',
     properties: {
-      id: {
-        type: 'integer'
-      },
-      title: {
-        type: 'string'
-      },
-      ordering: {
-        type: 'string',
-        format: 'date-time'
-      },
-      links: {
-        author: {
-          type: 'string'
+      data: {
+        required: true,
+        type: 'object',
+        properties: {
+          type: {
+            required: true,
+            type: 'string'
+          },
+          attributes: {
+            required: true,
+            type: 'object',
+            properties: {
+              id: {
+                type: 'integer'
+              },
+              title: {
+                type: 'string'
+              },
+              ordering: {
+                type: 'string',
+                format: 'date-time'
+              },
+              links: {
+                author: {
+                  type: 'string'
+                }
+              }
+            }
+          }
         }
+      },
+      relationships: {
+        required: false,
+        type: 'object',
       }
     }
   }

--- a/test/app/src/modules/series/schema.js
+++ b/test/app/src/modules/series/schema.js
@@ -1,11 +1,33 @@
 module.exports = {
   body: {
+    required: true,
+    type: 'object',
     properties: {
-      id: {
-        type: 'integer'
+      data: {
+        required: true,
+        type: 'object',
+        properties: {
+          type: {
+            required: true,
+            type: 'string'
+          },
+          attributes: {
+            required: true,
+            type: 'object',
+            properties: {
+              id: {
+                type: 'integer'
+              },
+              title: {
+                type: 'string'
+              },
+            }
+          }
+        }
       },
-      title: {
-        type: 'string'
+      relationships: {
+        required: false,
+        type: 'object',
       }
     }
   }

--- a/test/app/src/modules/stores/schema.js
+++ b/test/app/src/modules/stores/schema.js
@@ -1,11 +1,33 @@
 module.exports = {
   body: {
+    required: true,
+    type: 'object',
     properties: {
-      id: {
-        type: 'integer'
+      data: {
+        required: true,
+        type: 'object',
+        properties: {
+          type: {
+            required: true,
+            type: 'string'
+          },
+          attributes: {
+            required: true,
+            type: 'object',
+            properties: {
+              id: {
+                type: 'integer'
+              },
+              name: {
+                type: 'string'
+              },
+            }
+          }
+        }
       },
-      name: {
-        type: 'string'
+      relationships: {
+        required: false,
+        type: 'object',
       }
     }
   }

--- a/test/integration/json-api/v1/base-format/create/index.js
+++ b/test/integration/json-api/v1/base-format/create/index.js
@@ -45,6 +45,22 @@ describe('creatingResources', function() {
       });
   });
 
+  it('must respond to an invalid schema request with a JSON object containing a collection keyed by "errors" in the top level', function() {
+    bookData.attributes.title = {
+      invalid: 'attribute'
+    };
+    return Agent.request('POST', '/v1/books')
+      .send({
+        data: bookData
+      })
+      .promise()
+      .then(function(res) {
+        expect(res.status).to.be.within(400, 499); // any error
+        expect(res.body).to.be.an('object');
+        expect(res.body.errors).to.be.an('array');
+      });
+  });
+
   it('must require a content-type header of application/vnd.api+json', function() {
     return Agent.request('POST', '/v1/books')
       .type('application/json')

--- a/test/unit/validate-json-schema/index.js
+++ b/test/unit/validate-json-schema/index.js
@@ -17,7 +17,9 @@ describe('ValidateJSONSchema', () => {
   it('should return null when there is no schema on the endpoint', () => {
 
     var endpoint = {
-      schema: null
+      config: {
+        schema: null
+      }
     };
 
     var error = validateJSONSchema(request, endpoint);
@@ -39,8 +41,10 @@ describe('ValidateJSONSchema', () => {
     };
 
     var endpoint = {
-      schema: {
-        query: sortFilterRequiredSchema
+      config: {
+        schema: {
+          query: sortFilterRequiredSchema
+        }
       }
     };
 
@@ -62,8 +66,10 @@ describe('ValidateJSONSchema', () => {
     };
 
     var endpoint = {
-      schema: {
-        query: sortRequiredSchema
+      config: {
+        schema: {
+          query: sortRequiredSchema
+        }
       }
     };
 


### PR DESCRIPTION
I noticed that the schema validation was not working in the example app, so I decided to investigate.

I found that the validator was not able to find the schemas on `endpoint.schema`, but that the schema was available on `endpoint.config.schema`. https://github.com/endpoints/endpoints/blob/69b359b/src/validate-json-schema/index.js#L13

I also found that the schemas in the integration test app did not match valid JSON API schemas.

This PR fixes both of these issues and adds an integration test to catch this error. As previously these issues were undiscovered as they were unit tested in isolation.

@tkellen Does this look correct to you? If this is all ok, I'll update the example app too (this would close https://github.com/endpoints/endpoints-example/issues/6 I believe).